### PR TITLE
Update LD_LIBRARY_PATH

### DIFF
--- a/integrations/c/setup.md
+++ b/integrations/c/setup.md
@@ -17,6 +17,9 @@ mkdir wasmer-c-api
 tar -C wasmer-c-api -zxvf wasmer-c-api*.tar.gz
 
 export WASMER_C_API=`pwd`/wasmer-c-api
+
+# Update LD_LIBRARY_PATH to link against the libwasmer.so in the examples
+export LD_LIBRARY_PATH=`pwd`/wasmer-c-api/lib/:$LD_LIBRARY_PATH
 ```
 
 {% hint style="info" %}


### PR DESCRIPTION
Update `LD_LIBRARY_PATH` to be able to link against `libwasmer.so` when running the examples

this should fix this error:
```
./hello_world: error while loading shared libraries: libwasmer.so: cannot open shared object file: No such file or directory
```