### PR TITLE
Fix broken link in Rust Early Exit

### DIFF
--- a/integrations/rust/examples/exit-early.md
+++ b/integrations/rust/examples/exit-early.md
@@ -1,7 +1,7 @@
 # Interrupting Execution
 
 {% hint style="success" %}
-**Note**: The final code for this example can be found on [GitHub](https://github.com/wasmerio/docs.wasmer.io/tree/master/integrations/rust/examples/exit-early).
+**Note**: The final code for this example can be found on [GitHub](https://github.com/wasmerio/docs.wasmer.io/tree/master/integrations/rust/examples/early-exit).
 {% endhint %}
 
 WebAssembly is currently always run in the same process synchronously. Thus, once WebAssembly starts executing, you have to wait for the execution to complete to continue running code on the host \(your Rust application\).


### PR DESCRIPTION
The link at the top of the webpage points to the wrong URL on GitHub. It currently points to exit-early when it should point to early-exit. I fixed it, and it's the only change I made.