### PR TITLE
Update Rust API link in sidebar to new 1.0 crate

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -27,7 +27,7 @@
 
 * [Rust](integrations/rust/README.md)
   * [Setup your Rust environment](integrations/rust/setup.md)
-  * [Wasmer Rust API](https://docs.rs/wasmer-runtime/)
+  * [Wasmer Rust API](https://docs.rs/wasmer/)
 * [C/C++](integrations/c/README.md)
   * [Setup your C/C++ environment](integrations/c/setup.md)
   * [Wasmer C API](https://wasmerio.github.io/wasmer/c/)


### PR DESCRIPTION
The "Wasmer Rust API" link in the sidebar currently points to the deprecated
`wasmer-runtime` crate. This commit updates the link to instead point to the
new `wasmer` crate.