### PR TITLE
Fix Some Typos

### DIFF
--- a/integrations/examples/host-functions.md
+++ b/integrations/examples/host-functions.md
@@ -54,16 +54,16 @@ Because we want to store data outside of the Wasm module and have host functions
 {% tabs %}
 {% tab title="Rust" %}
 ```rust
-let shared_counter: Arc<RefCell<i32>> = Arc::new(RefCell::new(0));
+let shared_counter: Arc<Mutex<i32>> = Arc::new(Mutex::new(0));
 
 #[derive(WasmerEnv, Clone)]
 struct Env {
-    counter: Arc<RefCell<i32>>,
+    counter: Arc<Mutex<i32>>,
 }
 ```
 
 {% hint style="info" %}
-Here we use a combination of `Arc` and `RefCell` to guarantee thread safety while allowing mutability.
+Here we use a combination of `Arc` and `Mutex` to guarantee thread safety while allowing mutability.
 {% endhint %}
 {% endtab %}
 {% endtabs %}
@@ -76,11 +76,11 @@ Now that our data is available we'll declare the functions.
 {% tab title="Rust" %}
 ```rust
 fn get_counter(env: &Env) -> i32 {
-    *env.counter.borrow()
+    *env.counter.lock().unwrap()
 }
 
 fn add_to_counter(env: &Env, add: i32) -> i32 {
-    let mut counter_ref = env.counter.borrow_mut();
+    let mut counter_ref = env.counter.lock().unwrap();
 
     *counter_ref += add;
     *counter_ref

--- a/integrations/examples/imports-and-exports.md
+++ b/integrations/examples/imports-and-exports.md
@@ -9,7 +9,7 @@ description: >-
 
 In this example we'll be using a sample Wasm module which exports some entities and requires us to also import some of them.
 
-The goal here is to give you an idea of how to work with imports and exports. We won't go into the details of each entities, they'll be covered in more details in the other examples.
+The goal here is to give you an idea of how to work with imports and exports. We won't go into the details of each entity, they'll be covered in more details in the other examples.
 
 First we are going to want to initialize a new project. To do this we can navigate to our project folder, or create one. In this example, we will create a new project. Lets create it and navigate to it:
 

--- a/integrations/examples/instance.md
+++ b/integrations/examples/instance.md
@@ -264,7 +264,7 @@ fclose(file);
 
 The next step will be to compile the module. To do this, we'll need two things: the Wasm module as bytes and a `Store`.
 
-The `Store` is a representation of the actual state of the module: it represents the state of every entities in the module during its lifecycle. It also holds the engine which is what will be used to actually compile the module.
+The `Store` is a representation of the actual state of the module: it represents the state of every entity in the module during its lifecycle. It also holds the engine which is what will be used to actually compile the module.
 
 Here is how we can create the store and compile the module:
 


### PR DESCRIPTION
**This PR**
- Fixes some typos ("entities" -> "entity")
- Fixes a Rust example that uses `RefCell` when it shouldn't