### PR TITLE
Fix tab/typo in section Defining and importing the host function

### DIFF
--- a/integrations/examples/exit-early.md
+++ b/integrations/examples/exit-early.md
@@ -214,7 +214,7 @@ func = Wasmer::Function.new(store, method(:early_exit), func_type)
 import_object = Wasmer::ImportObject.new
 import_object.register("env", { :early_exit => func })
 ```
-{% endtag %}
+{% endtab %}
 {% endtabs %}
 
 As we saw in previous examples we defined a Rust function, wrap it in a native function definition and import it in the guest module, in the `env` namespace, using the `ImportObject`.


### PR DESCRIPTION
It seems that `endtag` instead of `endtab` in the Defining and importing the host function section (Ruby) breaks the tabs. Currently the "Ruby" tab is empty while there is a tab called "Untitled" with the content of the "Ruby" tab.

See: #128 