### PR TITLE
Add CosmWasm to wasmer docs

### DIFF
--- a/community/built-with-wasmer.md
+++ b/community/built-with-wasmer.md
@@ -52,7 +52,7 @@ description: "A place for all things Wasmer and WebAssembly. Feel free to add yo
 ## Blockchains
 
 * [NEAR Protocol](https://near.org/)
-* [CosmWasm] (https://github.com/CosmWasm/cosmwasm)
+* [CosmWasm] (https://cosmwasm.com)
 * [SpaceMesh](https://spacemesh.io/)
 * [ChainSafe](https://chainsafe.io/)
 * [Fluence Labs](https://fluence.network/)

--- a/community/built-with-wasmer.md
+++ b/community/built-with-wasmer.md
@@ -20,6 +20,7 @@ description: "A place for all things Wasmer and WebAssembly. Feel free to add yo
 * Nebula [source](https://github.com/nebula-os/npk)
 * Romy [source](https://github.com/catt-io/romy)
 * WAStyle [source](https://github.com/Menci/wastyle)
+* CosmWasm [source](https://github.com/CosmWasm/cosmwasm)
 
 ### Javascript
 

--- a/community/built-with-wasmer.md
+++ b/community/built-with-wasmer.md
@@ -20,7 +20,6 @@ description: "A place for all things Wasmer and WebAssembly. Feel free to add yo
 * Nebula [source](https://github.com/nebula-os/npk)
 * Romy [source](https://github.com/catt-io/romy)
 * WAStyle [source](https://github.com/Menci/wastyle)
-* CosmWasm [source](https://github.com/CosmWasm/cosmwasm)
 
 ### Javascript
 
@@ -53,7 +52,7 @@ description: "A place for all things Wasmer and WebAssembly. Feel free to add yo
 ## Blockchains
 
 * [NEAR Protocol](https://near.org/)
-* [Cosmos](https://cosmos.network/)
+* [CosmWasm] (https://github.com/CosmWasm/cosmwasm)
 * [SpaceMesh](https://spacemesh.io/)
 * [ChainSafe](https://chainsafe.io/)
 * [Fluence Labs](https://fluence.network/)

--- a/community/built-with-wasmer.md
+++ b/community/built-with-wasmer.md
@@ -52,7 +52,7 @@ description: "A place for all things Wasmer and WebAssembly. Feel free to add yo
 ## Blockchains
 
 * [NEAR Protocol](https://near.org/)
-* [CosmWasm] (https://cosmwasm.com)
+* [CosmWasm](https://cosmwasm.com)
 * [SpaceMesh](https://spacemesh.io/)
 * [ChainSafe](https://chainsafe.io/)
 * [Fluence Labs](https://fluence.network/)


### PR DESCRIPTION
Swapped Cosmos with CosmWasm to avoid confusion.
CosmWasm is a WASM execution environment works on top of Cosmos SDK,
it is not inbuilt in cosmos sdk nor built by the same organisation.