### PR TITLE
fix bug --command to --command-name

### DIFF
--- a/pages/runtime/cli.mdx
+++ b/pages/runtime/cli.mdx
@@ -15,7 +15,7 @@ wasmer run python/python
 Some commands, such as `cowsay` have multiple commands that we can run (eg. `cowsay` or `cowthink`)
 
 ```
-wasmer run syrusakbary/cowsay --command=cowthink Hello world
+wasmer run syrusakbary/cowsay --command-name=cowthink Hello world
 ```
 
 If in your current dir you have a `wasmer.toml` file, you can simply run the local package with:


### PR DESCRIPTION
for latest wasmer version `3.3.0`, I believe `--command` should be `--command-name`

```bash
[fanweixiao@cc-m1] ~/tmp/wasmer_test  
❯ wasmer run syrusakbary/cowsay --command=cowthink Hello world
error: Found argument '--command' which wasn't expected, or isn't valid in this context

	Did you mean '--command-name'?

	If you tried to supply `--command` as a value rather than a flag, use `-- --command`

USAGE:
    wasmer run <SOURCE>

For more information try --help

[fanweixiao@cc-m1] ~/tmp/wasmer_test  
❯ wasmer run syrusakbary/cowsay --command-name=cowthink Hello world                                                              ⏎
 _____________                                                        
( Hello world )
 -------------
        o   ^__^
         o  (oo)\_______
            (__)\       )\/\
               ||----w |
                ||     ||

```