### PR TITLE
Document the need for dynamic imports when `@wasmer/sdk` is used with `xterm.js`

### DIFF
--- a/pages/javascript-sdk.mdx
+++ b/pages/javascript-sdk.mdx
@@ -1,3 +1,7 @@
+import { Cards, Card } from "nextra-theme-docs";
+import { Tabs, Tab } from "nextra-theme-docs";
+import GitHubLogo from "@components/GitHubLogo.tsx";
+
 # The Wasmer JavaScript SDK
 
 The `@wasmer/sdk` package is Wasmer's SDK for JavaScript.
@@ -18,8 +22,6 @@ Some functionality supported by `@wasmer/sdk`:
 ## Quickstart
 
 First, add the [`@wasmer/sdk`][wasmer-sdk] to your project.
-
-import { Tabs, Tab } from "nextra-theme-docs";
 
 <Tabs items={["npm", "yarn", "pnpm"]}>
     <Tab>
@@ -79,11 +81,14 @@ on line 11.
 
 ## What Next?
 
-import { Cards, Card } from "nextra-theme-docs";
-
 <Cards>
     <Card title="API Docs" href="https://wasmerio.github.io/wasmer-js" target="_blank" />
-    <Card title="GitHub" href="https://github.com/wasmerio/wasmer-js" target="_blank" />
+    <Card
+        icon={<GitHubLogo />}
+        title="wasmerio/wasmer-js"
+        href="https://github.com/wasmerio/wasmer-js"
+        target="_blank"
+    />
     <Card title="Troubleshooting Common Problems" href="/javascript-sdk/explainers/troubleshooting" />
 </Cards>
 

--- a/pages/javascript-sdk.mdx
+++ b/pages/javascript-sdk.mdx
@@ -51,8 +51,8 @@ const instance = await pkg.entrypoint.run({
     args: ["-c", "print('Hello, World!')"],
 });
 
-const { code, stdoutUtf8 } = await instance.wait();
-console.log(`Python exited with ${code}: ${stdoutUtf8}`);
+const { code, stdout } = await instance.wait();
+console.log(`Python exited with ${code}: ${stdout}`);
 ```
 
 Breaking this down line-by-line...
@@ -74,8 +74,8 @@ command) with the arguments `-c "print('Hello, World!")` and gets an `Instance`
 which can be used to communicate with the running process.
 
 Line 10 - waits until the python interpreter has exited, then extracts the
-`code` and `stdoutUtf8` values from the output so they can be printed to
-the console on line 11.
+`code` and `stdout` values from the output so they can be printed to the console
+on line 11.
 
 ## What Next?
 

--- a/pages/javascript-sdk/explainers/troubleshooting.mdx
+++ b/pages/javascript-sdk/explainers/troubleshooting.mdx
@@ -2,7 +2,7 @@
 title: Troubleshooting Common Problems
 ---
 
-import { Callout } from "nextra-theme-docs";
+import { Callout, Steps } from "nextra-theme-docs";
 
 # Troubleshooting Common Problems
 
@@ -228,6 +228,80 @@ As of now, `@wasmer/sdk` does not support Node.js.
 To resolve this issue, you need to run your code in a supported browser
 environment rather than in Node.js.
 
-[wasm-types-polyfill]: https://github.com/wasmerio/wasmer/blob/e6438738d884d6fb4297ca2af90ab04459ddbbfb/lib/api/src/js/module.rs#L91-L110
+## ReferenceError: `document is not defined`
+
+When making a production build of your app, you might encounter an issue where
+worker threads fail to start up due to a `ReferenceError` exception.
+
+```
+Uncaught (in promise) ReferenceError: document is not defined
+    at index-bnmRepzq.js:1:21
+    at index-bnmRepzq.js:1:708
+```
+
+### Root Cause
+
+This issue arises because Web Workers do not have access to the DOM, and any
+attempt by the worker threads to access DOM elements will result in a crash.
+
+Something to be aware of is that each Web Worker in the threadpool will import
+`@wasmer/sdk` on startup to bring in the rest of its business logic.
+
+In production mode, a bundle often includes all dependencies, causing the
+`@wasmer/sdk` import to also execute top-level code from your dependencies. Some
+dependencies, like `xterm.js`, will [interact with the DOM][create-element] and
+inadvertently crash the worker.
+
+### Solution
+
+To resolve this issue, `@wasmer/sdk` should be dynamically imported, ensuring
+that the bundler puts it in a separate chunk from `xterm.js`. This approach
+prevents the worker from executing the DOM-related code in `xterm.js` and allows
+it to start up successfully.
+
+Here's how you can implement the fix:
+
+<Steps>
+
+### Modify your import statement
+
+Change the static import of `@wasmer/sdk` to a dynamic one. This tells the
+bundler to separate it into its own chunk, avoiding the unintentional execution
+of DOM-related code.
+
+```typescript
+// Before
+import { Wasmer, init, initializeLogger, Instance } from "@wasmer/sdk/dist/WasmerSDKBundled.js";
+
+// After
+const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk/dist/WasmerSDKBundled");
+```
+
+### Update your `vite.config.js`
+
+Ensure your Vite configuration doesn't add its own code top-level which might
+trigger a similar error.
+
+```js filename="vite.config.js" copy
+build: {
+    modulePreload: {
+        polyfill: false,
+    },
+},
+```
+
+### Rebuild and redeploy
+
+After making these changes, rebuild your app in production mode and redeploy it.
+</Steps>
+
+<Callout type="info">
+For a real-world example of this, check out the diff for
+[`wasmerio/wasmer-js#374`][pr-374] on GitHub.
+</Callout>
+
+[create-element]: https://github.com/xtermjs/xterm.js/blob/b3737d6ff0821b08ee791c6d261e35a3cf5cd317/src/common/Color.ts#L117
 [guesses]: https://github.com/wasmerio/wasmer/blob/e6438738d884d6fb4297ca2af90ab04459ddbbfb/lib/api/src/js/module.rs#L323-L328
+[pr-374]: https://github.com/wasmerio/wasmer-js/pull/374
 [wasm-bindgen]: https://github.com/rustwasm/wasm-bindgen
+[wasm-types-polyfill]: https://github.com/wasmerio/wasmer/blob/e6438738d884d6fb4297ca2af90ab04459ddbbfb/lib/api/src/js/module.rs#L91-L110

--- a/pages/javascript-sdk/tutorials/run.mdx
+++ b/pages/javascript-sdk/tutorials/run.mdx
@@ -368,6 +368,7 @@ $ npm run dev
     href="https://github.com/wasmerio/wasmer-js/tree/main/examples/markdown-editor"
     target="_blank" />
 
+[coi]: /javascript-sdk/explainers/troubleshooting#sharedarraybuffer-and-cross-origin-isolation
 [pulldown-cmark]: https://lib.rs/pulldown-cmark
 [rust]: https://rustup.rs/
 [explicit-url-imports]: https://vitejs.dev/guide/assets#explicit-url-imports

--- a/pages/javascript-sdk/tutorials/xterm-js.mdx
+++ b/pages/javascript-sdk/tutorials/xterm-js.mdx
@@ -101,7 +101,7 @@ Now, we move to the core logic of our application in TypeScript. Start with
 importing necessary modules:
 
 ```typescript filename="index.ts" copy
-import { Instance, Wasmer, init, initializeLogger } from "@wasmer/sdk";
+import type { Instance } from "@wasmer/sdk";
 import { Terminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 ```
@@ -112,13 +112,23 @@ Next, let's create a `main()` function and initialize `@wasmer/sdk`.
 
 ```typescript filename="index.ts" copy
 async function main() {
+    const { Wasmer, init, initializeLogger } = await import("@wasmer/sdk");
+
     await init();
 
     /* ... */
 }
 ```
 
-<Callout>
+<Callout type="warning">
+You have may noticed that we're using a dynamic import (`await import("@wasmer/sdk")`) to pull in `@wasmer/sdk` rather than a "normal" `import { ... } from "@wasmer/sdk"`.
+
+This is a workaround for a bad interaction between bundlers, `xterm`, and the
+`@wasmer/sdk` threadpool. See [ReferenceError: `document is not
+defined``][document-undefined] for more details.
+</Callout>
+
+<Callout type="info">
 Call `init()` to load and set up the WebAssembly environment required by
 `@wasmer/sdk`. It's crucial to do this before using any other functionality of
 the SDK.
@@ -287,3 +297,4 @@ are endless, and the power of WebAssembly makes it all possible in the browser.
 [xterm-js]: https://xtermjs.org/
 [bash]: https://wasmer.io/sharrattj/bash
 [coi]: /javascript-sdk/explainers/troubleshooting#sharedarraybuffer-and-cross-origin-isolation
+[document-undefined]: /javascript-sdk/explainers/troubleshooting#referenceerror-document-is-not-defined


### PR DESCRIPTION
Fixes SDK-49, SDK-50 and SDK-51.