### PR TITLE
Update run.mdx to have clearer instructions

### DIFF
--- a/pages/javascript-sdk/tutorials/run.mdx
+++ b/pages/javascript-sdk/tutorials/run.mdx
@@ -173,6 +173,15 @@ The next step is to compile this Rust program to WebAssembly. This will give us
 an executable that can be run anywhere Wasmer runs, although for our use case we
 are mostly concerned about running it in the browser.
 
+<Callout type="info">
+If you haven't already, you may need to [install Rust][rust] and use `rustup` to
+add the `wasm32-wasi` target:
+
+```sh copy
+rustup target add wasm32-wasi
+```
+</Callout>
+
 ```sh copy
 cargo build --release --target=wasm32-wasi
 ```
@@ -183,15 +192,6 @@ This should create a `markdown-renderer.wasm` file under `target/`:
 $ file target/wasm32-wasi/release/*.wasm
 target/wasm32-wasi/release/markdown-renderer.wasm: WebAssembly (wasm) binary module version 0x1 (MVP)
 ```
-
-<Callout type="info">
-If you haven't already, you may need to [install Rust][rust] and use `rustup` to
-add the `wasm32-wasi` target:
-
-```sh copy
-rustup target add wasm32-wasi
-```
-</Callout>
 
 ### TypeScript Setup & Initialization
 


### PR DESCRIPTION
I got momentarily stuck by the errors returned by running `cargo build --release --target=wasm32-wasi` before installing the `wasm32-wasi`

I know it was just a couple of lines below, but I didn't even think to see forward while something was failing to run


