### PR TITLE
fix snippet in js sdk example

### DIFF
--- a/pages/javascript-sdk/tutorials/run.mdx
+++ b/pages/javascript-sdk/tutorials/run.mdx
@@ -248,7 +248,7 @@ async function renderMarkdown(module: WebAssembly.Module, markdown: string) {
     await stdin.close();
 
     const result = await instance.wait();
-    return result.ok ? result.stdoutUtf8 : null;
+    return result.ok ? result.stdout : null;
 }
 ```
 


### PR DESCRIPTION
`result.stdoutUtf8` is not present in the object, result.stdout is