### PR TITLE
Fix failing CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,3 +1,5 @@
+name: publish
+
 on:
   pull_request:
   push:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -17,8 +17,6 @@ jobs:
 
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v2
-        with:
-          version: "v4.0.0"
 
       - name: Install pnpm
         uses: pnpm/action-setup@v2

--- a/app.yaml
+++ b/app.yaml
@@ -1,8 +1,9 @@
+kind: wasmer.io/App.v0
 name: wasmer-docs
-app_id: da_4K6AIot5UVP2
 owner: wasmer
 package: .
 domains:
-- wasmer-docs.wasmer.app
-- docs.wasmer.io
-kind: wasmer.io/App.v0
+  - wasmer-docs.wasmer.app
+  - docs.wasmer.io
+
+app_id: da_4K6AIot5UVP2


### PR DESCRIPTION
Because the CI was using an old version of wasmer (v4.0.0 instead of v4.3.1), CI started failing with the latest changes.
This PR fixes these issues.