### PR TITLE
on page /registry: fix broken link to package search

### DIFF
--- a/pages/registry.mdx
+++ b/pages/registry.mdx
@@ -7,7 +7,7 @@ import PublishIcon from '../components/icons/publish.svg'
 The Wasmer Registry stores all Wasmer packages and allows exploring packages from other users and distribute your own ones.
 
 You can explore packages published to the Wasmer Registry at [wasmer.io](https://wasmer.io/explore) or you can
-also [search for packages](/registry/search).
+also [search for packages](https://wasmer.io/search?type=PACKAGE).
 
 ## 🐥 First Steps
 


### PR DESCRIPTION
this PR fixes the first part of issue #91, namely,

> Firstly, on the docs registry page (docs.wasmer.io/registry) the
> "search for packages" link 404s.