### PR TITLE
Revert "on page /registry: fix broken link to package search"

### DIFF
--- a/pages/registry.mdx
+++ b/pages/registry.mdx
@@ -7,7 +7,7 @@ import PublishIcon from '../components/icons/publish.svg'
 The Wasmer Registry stores all Wasmer packages and allows exploring packages from other users and distribute your own ones.
 
 You can explore packages published to the Wasmer Registry at [wasmer.io](https://wasmer.io/explore) or you can
-also [search for packages](https://wasmer.io/search?type=PACKAGE).
+also [search for packages](/registry/search).
 
 ## 🐥 First Steps
 


### PR DESCRIPTION
Reverts wasmerio/docs.wasmer.io#92