### PR TITLE
Cleaned up the docs for registry and runtime

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -11,7 +11,7 @@ Welcome to the Wasmer Documentation! 👋
 ## Ecosystem
 
 1. [Wasmer Runtime](/runtime): allows running Wasmer containers anywhere
-2. [Wasmer Registry](/registry): explore containers from the community and distribute your own ones
+2. [Wasmer Registry](/registry): explore containers from the community and distribute your own
 3. [Wasmer Edge](/edge): run containers on Wasmer distributed Edge infrastructure
 
 <Cards>
@@ -23,14 +23,15 @@ Welcome to the Wasmer Documentation! 👋
 
 ## SDKs
 
-Wasmer is available in multiple programming languages and operating systems.
+Wasmer is available in multiple programming languages and operating systems in the shape of SDKs.
+Using these SDKs, it's possible to embedd wasmer modules compiled from other languages into your application.
 We have set up the SDKs to allow using Wasmer easily anywhere:
 
 * [Wasmer JavaScript SDK](/sdk/wasmer-js): run your Wasmer packages in Javascript
 
 ## Social
 
-For the latest articles on Wasmer features and developments, check out [our blog](https://wasmer.io/posts) or [follow us on Twitter](https://twitter.com/wasmerio)!
+For the latest articles on Wasmer features and developments, check out [our blog](https://wasmer.io/posts) or [follow us on X](https://x.com/wasmerio)!
 You can also chat with us using [Wasmer Discord channel](https://discord.com/invite/qBTfsNP7N8).
 
 Let's now dig deeper into how to install Wasmer, shall we? 🙂

--- a/pages/install.mdx
+++ b/pages/install.mdx
@@ -3,7 +3,7 @@
 import { Callout } from "nextra-theme-docs";
 import { Tabs, Tab } from "nextra-theme-docs";
 
-Wasmer allows you to run applications either **Standalone** (_via the CLI_) or **Embedded** within [other languages](./#wasmer-language-integrations) such as C/C++, Rust, Python, Go, PHP, Ruby...
+Wasmer allows you to run applications either **Standalone** (_via the CLI_) or **Embedded** within [other languages](./#sdks) such as C/C++, Rust, Python, Go, PHP, Ruby...
 
 <Tabs items={['CLI (Bash)', 'CLI (PowerShell)', 'JS' /*, 'Python' */]}>
   <Tab>

--- a/pages/registry/cli.mdx
+++ b/pages/registry/cli.mdx
@@ -10,7 +10,7 @@ import { Callout } from "nextra-theme-docs";
 
 Creating a package is very simple, just run:
 
-```bash
+```bash copy
 wasmer init
 ```
 
@@ -18,7 +18,7 @@ wasmer init
 
 Once you set up the values in your [`wasmer.toml` manifest](/registry/manifest), publishing a package to Wasmer is as simple as running the following command:
 
-```bash
+```bash copy
 wasmer publish
 ```
 
@@ -32,7 +32,7 @@ This command will create your Wasmer package, and publish it to the Wasmer regis
 
 If you want to check that everything is running properly before publishing, you can run `--dry-run`:
 
-```bash
+```bash copy
 wasmer publish --dry-run
 ```
 
@@ -47,44 +47,110 @@ You can set the configuration for the registry very easily.
 ### `registry.url`: Registry URL 
 
 Get:
-```
+```bash copy
 wasmer config get registry.url
 ```
 
 Set:
-```
+``` bash copy
 wasmer config set registry.url https://registry.wasmer.io/graphql
 ```
 
 ## Help
 
-This is the help output from the Wasmer CLI for `wasmer publish --help`:
+This is the help output from the Wasmer CLI for `wasmer publish --help` (last updated 2025-01):
 
 ```
-Usage: wasmer publish [OPTIONS] [PACKAGE_PATH]
+Publish a package to a registry [alias: package publish]
+
+Usage: wasmer publish [OPTIONS] [path]
 
 Arguments:
-  [PACKAGE_PATH]
+  [path]
           Directory containing the `wasmer.toml`, or a custom *.toml manifest file.
+          
           Defaults to current working directory.
+          
+          [default: .]
 
 Options:
+      --wasmer-dir <WASMER_DIR>
+          Set Wasmer's home directory
+          
+          [env: WASMER_DIR=/home/imago/.local/share/wasmenv/current]
+          [default: /home/imago/.local/share/wasmenv/current]
+
+      --cache-dir <CACHE_DIR>
+          The directory cached artefacts are saved to
+          
+          [env: WASMER_CACHE_DIR=/home/imago/.wasmer/cache]
+          [default: /home/imago/.local/share/wasmenv/current/cache]
+
+  -v, --verbose...
+          Generate verbose output (repeat for more verbosity)
+
       --registry <REGISTRY>
-          Registry to publish to
-      --dry-run
-          Run the publish logic without sending anything to the registry server
-      --quiet
-          Run the publish command without any output
-      --package-name <PACKAGE_NAME>
-          Override the package of the uploaded package in the wasmer.toml
-      --version <VERSION>
-          Override the package version of the uploaded package in the wasmer.toml
+          The registry to fetch packages from (inferred from the environment by default)
+          
+          [env: WASMER_REGISTRY=]
+
+      --log-format <LOG_FORMAT>
+          The format to use when generating logs
+          
+          [env: LOG_FORMAT=]
+          [default: text]
+
+          Possible values:
+          - text: Human-readable logs
+          - json: Machine-readable logs
 
       --token <TOKEN>
-          Override the token (by default, it will use the current logged in user)
+          The API token to use when communicating with the registry (inferred from the environment by default)
+          
+          [env: WASMER_TOKEN=wap_1f8cd65ed491ab8087f54f8078f389a7bb6e7236c808aac61a487b4236f90d2f]
+
+      --color <COLOR>
+          When to display colored output
+          
+          [default: auto]
+          [possible values: auto, always, never]
+
+      --dry-run
+          Run the publish logic without sending anything to the registry server
+
+      --quiet
+          Run the publish command without any output
+
+      --namespace <PACKAGE_NAMESPACE>
+          Override the namespace of the package to upload
+
+      --name <PACKAGE_NAME>
+          Override the name of the package to upload
+
+      --version <PACKAGE_VERSION>
+          Override the package version of the uploaded package in the wasmer.toml
 
       --no-validate
           Skip validation of the uploaded package
+
+      --wait[=<WAIT>]
+          Wait for package to be available on the registry before exiting
+          
+          [default: none]
+          [possible values: none, container, native-executables, bindings, all]
+
+      --timeout <TIMEOUT>
+          Timeout (in seconds) for the publish query to the registry.
+          
+          Note that this is not the timeout for the entire publish process, but for each individual query to the registry during the publish flow.
+          
+          [default: 5m]
+
+      --bump
+          Whether or not the patch field of the version of the package - if any - should be bumped
+
+      --non-interactive
+          Do not prompt for user input
 
   -h, --help
           Print help (see a summary with '-h')

--- a/pages/registry/get-started.mdx
+++ b/pages/registry/get-started.mdx
@@ -38,6 +38,8 @@ module = '<your-module>'
 
 You can check the manifest format here: [Wasmer Package Manifest](/registry/manifest).
 
+The **`wasmer.toml`** file is in the **Wasmer** ecosystem what a **`package.json`** is in the **Node** ecosystem, or **`pyproject.toml`** in the **Python** ecosystem.
+
 <Callout type="info">
 Once you have a `wasmer.toml` manifest, you can simply execute `wasmer run` in the CLI to run your package locally.
 
@@ -54,7 +56,7 @@ Now, create your WebAssembly modules:
 <Tabs items={['Rust (WASIX)', 'Rust (WASI)']}>
   <Tab>
 
-    ```bash
+    ```bash copy
     cargo install cargo-wasix
     cargo wasix build --release
     ```
@@ -63,7 +65,7 @@ Now, create your WebAssembly modules:
   <Tab>
     WASI is oficially supported by Rust, to compile to it you can simply do:
 
-    ```bash
+    ```bash copy
     rustup target add wasm32-wasi
     cargo build --target=wasm32-wasi
     ```
@@ -77,7 +79,7 @@ Modify the `wasmer.toml` to point the module to the wasm file location `target/r
 
 Now, simply run:
 
-```bash
+```bash copy
 wasmer publish
 ```
 

--- a/pages/runtime/_meta.json
+++ b/pages/runtime/_meta.json
@@ -1,6 +1,6 @@
 {
   "get-started": "Getting Started",
   "cli": "CLI",
-  "runners": "Runners",
-  "features": "Features"
+  "features": "Features",
+  "runners": "Runners"
 }

--- a/pages/runtime/cli.mdx
+++ b/pages/runtime/cli.mdx
@@ -8,38 +8,38 @@ Run a WebAssembly file or Wasmer container.
 
 All packages published on [Wasmer Registry](/registry) can be run with the `wasmer run` command.
 
-```bash
+```bash copy
 wasmer run python/python
 ```
 
 Some commands, such as `cowsay` have multiple commands that we can run (eg. `cowsay` or `cowthink`)
 
-```bash
+```bash copy
 wasmer run syrusakbary/cowsay --command-name=cowthink Hello world
 ```
 
 If in your current dir you have a `wasmer.toml` file, you can simply run the local package with:
 
-```bash
+```bash copy
 wasmer run .
 ```
 
 Wasmer run also allows running from URLs (in case a package is hosted on a different registry).
 
-```bash
+```bash copy
 wasmer run https://wasmer.io/python/python
 ```
 
 
 ### Run a Wasm file
 
-```bash
+```bash copy
 wasmer run my_program.wasm
 ```
 
 #### Run a Wasm file with a custom compiler
 
-```bash
+```bash copy
 wasmer run my_program.wasm --singlepass
 ```
 
@@ -49,22 +49,24 @@ wasmer run my_program.wasm --singlepass
 
 You can pass the arguments that will be given to the WASI program:
 
-```bash
+```bash copy
 wasmer run my_wasi_program.wasm -- arg1 arg2 arg3
 ```
 
 You can also pass environment variables:
 
-```bash
+```bash copy
 wasmer run my_wasi_program.wasm --env MYVAR=MYVALUE -- arg1 arg2 arg3
 ```
 
 
 ## Help
 
-This is the help output from the Wasmer CLI for `wasmer run --help`:
+This is the help output from the Wasmer CLI for `wasmer run --help` (last updated 2025-01):
 
 ```
+Run a WebAssembly file or Wasmer container
+
 Usage: wasmer run [OPTIONS] <INPUT> [ARGS]...
 
 Arguments:
@@ -75,17 +77,49 @@ Arguments:
           Command-line arguments passed to the package
 
 Options:
-  -v, --verbose...
-          More output per occurrence
-
-  -q, --quiet...
-          Less output per occurrence
-
       --wasmer-dir <WASMER_DIR>
-          The Wasmer home directory
+          Set Wasmer's home directory
+          
+          [env: WASMER_DIR=/home/imago/.local/share/wasmenv/current]
+          [default: /home/imago/.local/share/wasmenv/current]
 
-          [env: WASMER_DIR=/Users/syrusakbary/.wasmer]
-          [default: /Users/syrusakbary/.wasmer]
+      --cache-dir <CACHE_DIR>
+          The directory cached artefacts are saved to
+          
+          [env: WASMER_CACHE_DIR=/home/imago/.wasmer/cache]
+          [default: /home/imago/.local/share/wasmenv/current/cache]
+
+  -v, --verbose...
+          Generate verbose output (repeat for more verbosity)
+
+  -q, --quiet
+          Do not print progress messages
+
+      --registry <REGISTRY>
+          The registry to fetch packages from (inferred from the environment by default)
+          
+          [env: WASMER_REGISTRY=]
+
+      --log-format <LOG_FORMAT>
+          The format to use when generating logs
+          
+          [env: LOG_FORMAT=]
+          [default: text]
+
+          Possible values:
+          - text: Human-readable logs
+          - json: Machine-readable logs
+
+      --token <TOKEN>
+          The API token to use when communicating with the registry (inferred from the environment by default)
+          
+          [env: WASMER_TOKEN=wap_1f8cd65ed491ab8087f54f8078f389a7bb6e7236c808aac61a487b4236f90d2f]
+
+      --color <COLOR>
+          When to display colored output
+          
+          [default: auto]
+          [possible values: auto, always, never]
 
       --singlepass
           Use Singlepass compiler
@@ -97,7 +131,14 @@ Options:
           Use LLVM compiler
 
       --enable-verifier
-          Enable compiler internal verification
+          Enable compiler internal verification.
+          
+          Available for cranelift, LLVM and singlepass.
+
+      --llvm-debug-dir <LLVM_DEBUG_DIR>
+          LLVM debug directory, where IR and object files will be written to.
+          
+          Only available for the LLVM compiler.
 
       --enable-simd
           Enable support for the SIMD proposal
@@ -130,8 +171,8 @@ Options:
           Pass custom environment variables
 
       --forward-host-env
-          Forward all host env variables to the wcgi task
-
+          Forward all host env variables to guest
+          
           [env: FORWARD_HOST_ENV=]
 
       --use <USE>
@@ -143,10 +184,24 @@ Options:
       --map-command <MAPCMD>
           List of injected atoms
 
-      --net
+      --net[=<NETWORKING>]
           Enable networking with the host network.
-
+          
           Allows WASI modules to open TCP and UDP connections, create sockets, ...
+          
+          Optionally, a set of network filters could be defined which allows fine-grained control over the network sandbox.
+          
+          Rule Syntax:
+          
+          <rule-type>:<allow|deny>=<rule-expression>
+          
+          Examples:
+          
+          - Allow a specific domain and port: dns:allow=example.com:80
+          
+          - Deny a domain and all its subdomains on all ports: dns:deny=*danger.xyz:*
+          
+          - Allow opening ipv4 sockets only on a specific IP and port: ipv4:allow=127.0.0.1:80/in.
 
       --no-tty
           Disables the TTY bridge
@@ -154,22 +209,50 @@ Options:
       --enable-async-threads
           Enables asynchronous threading
 
+      --enable-cpu-backoff <ENABLE_CPU_BACKOFF>
+          Enables an exponential backoff (measured in milli-seconds) of the process CPU usage when there are no active run tokens (when set holds the maximum amount of time that it will pause the CPU) (default = off)
+
+      --journal <JOURNALS>
+          Specifies one or more journal files that Wasmer will use to restore and save the state of the WASM process as it executes.
+          
+          The state of the WASM process and its sandbox will be reapplied using the journals in the order that you specify here.
+          
+          The last journal file specified will be created if it does not exist and opened for read and write. New journal events will be written to this file
+
+      --enable-compaction
+          Flag that indicates if the journal will be automatically compacted as it fills up and when the process exits
+
+      --without-compact-on-drop
+          Tells the compactor not to compact when the journal log file is closed
+
+      --with-compact-on-growth <WITH_COMPACT_ON_GROWTH>
+          Tells the compactor to compact when it grows by a certain factor of its original size. (i.e. '0.2' would be it compacts after the journal has grown by 20 percent)
+          
+          Default is to compact on growth that exceeds 15%
+          
+          [default: 0.15]
+
+      --snapshot-on <SNAPSHOT_ON>
+          Indicates what events will cause a snapshot to be taken and written to the journal file.
+          
+          If not specified, the default is to snapshot when the process idles, when the process exits or periodically if an interval argument is also supplied.
+          
+          Additionally if the snapshot-on is not specified it will also take a snapshot on the first stdin, environ or socket listen - this can be used to accelerate the boot up time of WASM processes.
+
+      --snapshot-period <SNAPSHOT_INTERVAL>
+          Adds a periodic interval (measured in milli-seconds) that the runtime will automatically take snapshots of the running process and write them to the journal. When specifying this parameter it implies that `--snapshot-on interval` has also been specified
+
       --http-client
           Allow instances to send http requests.
-
+          
           Access to domains is granted by default.
 
       --deny-multiple-wasi-versions
           Require WASI modules to only import 1 version of WASI
 
-      --registry <REGISTRY>
-          The registry to use
-
-          [env: WASMER_REGISTRY=]
-
   -a, --addr <ADDR>
           The address to serve on
-
+          
           [env: ADDR=]
           [default: 127.0.0.1:8000]
 
@@ -177,10 +260,20 @@ Options:
           Set the default stack size (default is 1048576)
 
   -e, --entrypoint <ENTRYPOINT>
-          The function or command to invoke
+          The entrypoint module for webc packages
 
-      --COREDUMP PATH <COREDUMP PATH>
+  -i, --invoke <INVOKE>
+          The function to invoke
+
+      --COREDUMP_PATH <COREDUMP_PATH>
           Generate a coredump at this path if a WebAssembly trap occurs
+
+      --hash-algorithm <HASH_ALGORITHM>
+          Hashing algorithm to be used for module hash
+
+          Possible values:
+          - sha256:  Sha256
+          - xx-hash: XXHash
 
   -h, --help
           Print help (see a summary with '-h')

--- a/pages/runtime/features.mdx
+++ b/pages/runtime/features.mdx
@@ -6,7 +6,7 @@ Wasmer is powered by [WebAssembly](https://webassembly.org).
 
 Wasmer supports many different backends, depending on your needs:
 * Wasmer Native Backends:
-  - _Singlepass_: incredibly fast compilation times, ideal for Blockchains
+  - _Singlepass_: incredibly fast compilation times, ideal for Blockchain [Smart Contracts](https://en.wikipedia.org/wiki/Smart_contract)
   - _Cranelift_: normal compilation times, good performance
   - _LLVM_: slow compilation times, great performance
 * Other Runtimes:
@@ -34,6 +34,11 @@ Each of this backends support different features, and have different support for
 
 WebAssembly features:
 
+- ✅ Supported
+- 🔄 In the works
+- ❌ Not yet supported (please ping us if you need this feature!)
+
+
 |                                       | Singlepass | Cranelift | LLVM | JavascriptCore | Browser |
 | ------------------------------------- | ---------- | --------- | ---- | -------------- | ------- |
 | Bulk memory operations                | ✅         | ✅        | ✅   | ✅             | ✅      |
@@ -49,14 +54,9 @@ Wasmer features:
 
 | Features | Singlepass | Cranelift | LLVM | JavascriptCore | Browser |
 | -------- | ---------- | --------- | ---- | -------------- | ------- |
-| Caching  | ✅         | ✅        | ✅   | ❌             | ❌\*    |
+| Caching  | ✅         | ✅        | ✅   | ❌             | ❌      |
 | Metering | ✅         | ✅        | ✅   | ❌             | ❌      |
 
-> Legend:
-
-- ✅ Supported
-- 🔄 In the works
-- ❌ Not yet supported (please ping us if you need this feature!)
 
 ## Backend support by Operating System
 

--- a/pages/runtime/runners/create.mdx
+++ b/pages/runtime/runners/create.mdx
@@ -4,7 +4,7 @@ Runners allow anyone to create custom ways to run Wasmer packages / WebAssembly 
 
 This can be incredibly useful for different use cases:
 * You are a game creator such as [WASM-4](https://wasm4.org/), or others, and you want to create a custom runner so your games can be published and run with Wasmer.
-* You have created a new ABI for using, for example, WebGPU in the server and the browser and you want to allow those programs to be published and run with Wasmer.
+* You have created a new [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) for using, for example, WebGPU in the server and the browser and you want to allow those programs to be published and run with Wasmer.
 
 Other use cases?
 

--- a/pages/runtime/runners/wasix.mdx
+++ b/pages/runtime/runners/wasix.mdx
@@ -1,10 +1,10 @@
 # WASIX Runner
 
-WASIX is the long term stabilization and support of the existing WASI ABI
+WASIX is the long term stabilization and support of the existing [WASI ABI](https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md)
 plus additional non-invasive syscall extensions that complete the missing
-gaps sufficiently enough to enable real, practical and useful applications to be compiled and used now.
+gaps sufficiently enough to enable real, practical and useful applications to be compiled and used.
 
-WASIX was created by the Wasmer team to speed up the ecosystem around the WASI so that the Wasm’ification of code bases around the world can really start today!
+WASIX was created by the Wasmer team to speed up the Wasmification of codebases around the world!
 
 You can check more about WASIX on the [website](https://wasix.org/).
 

--- a/pages/runtime/runners/wcgi.mdx
+++ b/pages/runtime/runners/wcgi.mdx
@@ -1,6 +1,6 @@
 # WCGI Runner
 
-WCGI allows you to use normal CGI applications in WebAssembly.
+WCGI allows you to use normal [CGI](https://en.wikipedia.org/wiki/Common_Gateway_Interface) applications in WebAssembly.
 It is a simple wrapper around the WASI interface.
 
 If you have a CGI program, just try to compile it to WebAssembly and WASI and run it with WCGI.


### PR DESCRIPTION
Changes:
* Made all code fields copyable
* Cleaned up some formulations and spelling mistakes
* Moved the 'Features' so that it appears before 'Runners' section, I felt this it was a much more engaging page during a first time read
* Fixed some broken links