### PR TITLE
2025 01 10 edge docs cleanup

### DIFF
--- a/components/deploy/quickstart/TerminalLeft.mdx
+++ b/components/deploy/quickstart/TerminalLeft.mdx
@@ -1,4 +1,4 @@
 ```shell copy filename="wasmer-hello"
-$ wasmer run ./target/wasm32-wasmer-wasi/release/wasmer-hello.wasm --env PORT=3000
+wasmer run ./target/wasm32-wasmer-wasi/release/wasmer-hello.wasm --env PORT=3000
 Listening on http://127.0.0.1:3000
 ```

--- a/components/login.mdx
+++ b/components/login.mdx
@@ -4,6 +4,6 @@ Create a new account in [Wasmer](https://wasmer.io/signup).
 Then, log in into the Wasmer CLI and follow the provided steps to provide
 the CLI access to your Wasmer account.
 
-```bash
+```bash copy
 wasmer login
 ```

--- a/pages/edge/cli.mdx
+++ b/pages/edge/cli.mdx
@@ -20,32 +20,33 @@ The most important ones are `wasmer deploy` and the subcommands of `wasmer app`.
 To deploy an app to the Wasmer Edge, the user can use the `wasmer deploy` command.
 
 
-```shell
-$ wasmer deploy --help
-Deploy an app to Wasmer Edge
+```console
+wasmer deploy --help
+
+Deploy apps to Wasmer Edge [alias: app deploy]
 
 Usage: wasmer deploy [OPTIONS]
 
 Options:
+      --wasmer-dir <WASMER_DIR>
+          Set Wasmer's home directory
 
-      --publish-package
-          Automatically publish the package referenced by this app.
-          
-          Only works if the corresponding wasmer.toml is in the same directory.
+          [env: WASMER_DIR=/home/imago/.local/share/wasmenv/current]
+          [default: /home/imago/.local/share/wasmenv/current]
 
-      --path <PATH>
-          The path to the app.yaml file
+      --cache-dir <CACHE_DIR>
+          The directory cached artefacts are saved to
 
-      --no-wait
-          Do not wait for the app to become reachable
-      
-      --owner <OWNER>
-          Specify the owner (user or namespace) of the app.
-          
-		  If specified via this flag, the owner will be overridden.  Otherwise,
-		  the `app.yaml` is inspected and, if there is no `owner` field in the
-		  spec file, the user will be prompted to select the correct owner. If
-		  no owner is found in non-interactive mode the deployment will fail.
+          [env: WASMER_CACHE_DIR=/home/imago/.wasmer/cache]
+          [default: /home/imago/.local/share/wasmenv/current/cache]
+
+  -v, --verbose...
+          Generate verbose output (repeat for more verbosity)
+
+      --registry <REGISTRY>
+          The registry to fetch packages from (inferred from the environment by default)
+
+          [env: WASMER_REGISTRY=]
       ...
 ```
 
@@ -60,7 +61,7 @@ there are two kinds of deployment - just as mentioned above for the `wasmer app
 create` command - which entail two different flows. 
 
 In one case the user refers to a package already existing in the registry - in
-this case [the `package` field](/edge/configuration/app-configuration#package)
+this case [the `package` field](/edge/configuration#package)
 in the `app.yaml` file will refer to an identifier of the package (e.g.
 `wasmer/hello`). In the other case, when the user has a custom local package
 that they want to upload and use, the `package` field will contain the path to
@@ -78,7 +79,7 @@ Once these matters are decided upon, this deployment flow concludes just as the
 former: your app is available!
 
 ```shell
-$ wasmer deploy                                             
+wasmer deploy                                             
 ...
 ✔ Who should own this app? · <your-app> 
 ✔ What should be the name of the app? · <your-app-name> 
@@ -121,7 +122,7 @@ The `wasmer app info` command provides a synthesis of these informations, in
 particular the app name, the owner of the app, and relevant URLs.
 
 ```
-$ wasmer app info       
+wasmer app info       
   App Info  
 → Name: <your-app-name> 
 → Owner: <you> 
@@ -142,33 +143,24 @@ The Wasmer CLI allows users to intentionally create an app, but if a user runs
 `wasmer deploy` without an app available, the app creation process will be
 triggered.
 
-```shell
-$ wasmer app create --help
+```console
+wasmer app create --help
+
 Create a new Edge app
 
 Usage: wasmer app create [OPTIONS]
 
 Options:
-  -t, --type <type>
-          Possible values:
-          - http:           A HTTP server
-          - static-website: A static website
-          - browser-shell:  Wraps another package to run in the browser
-          - js-worker:      Winter-js based JS-Worker
-          - py-application: Python worker
+      --template <TEMPLATE>
+          A reference to the template to use.
 
-      --deploy
-          Whether or not to deploy the application once it is created.
-          
-		  If selected, this might entail the step of publishing the package
-		  related to the application. By default, the application is not
-		  deployed and the package is not published.
+          It can be either an URL to a github repository - like `https://github.com/wasmer-examples/php-wasmer-starter` -  or the name of a template that will be searched for in the selected registry, like `astro-starter`.
+
+      --package <PACKAGE>
+          Name of the package to use
 
   -v, --verbose...
           Generate verbose output (repeat for more verbosity)
-
-      --no-validate
-          Skip local schema validation
 
   ...
 ```
@@ -185,7 +177,7 @@ Once the metadata about the app are available, the user must decide the _kind_
 of app they want to deploy. 
 
 ```shell
-$ wasmer app create  
+wasmer app create  
 ...
 ? What would you like to deploy? ›
   Start with a template
@@ -202,7 +194,7 @@ from an existing package, like
 [`wasmer/hello`](https://wasmer.io/wasmer/hello).
 
 ```shell
-$ wasmer app create 
+wasmer app create 
 ...
 ✔ What would you like to deploy? · Choose an existing package
 ✔ What is the name of the package? · wasmer/hello

--- a/pages/edge/guides/cdn.mdx
+++ b/pages/edge/guides/cdn.mdx
@@ -44,7 +44,7 @@ The above command will give you the following prompt:
 ✔ Unpacked template
 ✔ Do you want to deploy the app now? · no
 ```
-The prompt may vary depending depending on wasmer runtime version, look for the CDN starter.
+The prompt may vary depending depending on wasmer runtime version, **look for the CDN starter**.
 
 The above command will initialize a project with the following structure.
 
@@ -113,7 +113,7 @@ The files you've put into the `./public` directory is now accessible from anywhe
 </Callout>
 
 <Callout type="info" emoji="ℹ">
-    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
 </Callout>
 
 ### Accessing the files

--- a/pages/edge/guides/cdn.mdx
+++ b/pages/edge/guides/cdn.mdx
@@ -29,96 +29,24 @@ We'll initialize the project with the `static-site` template.
 
 Navigate to the directory where you want to create the project and run the following command:
 
-```bash
-$ wasmer app create
+```bash copy
+wasmer app create
 ```
 
 The above command will give you the following prompt:
 
 ```bash
-App type:
-> Static website # Select Static website
-  HTTP server
-  Browser shell
-  JS Worker (experimental)
-  Python Application
-Who should own this package?: <your-namespace>
-No package found or specified.
-What should the package be called? It will be published under wasmer: <your-app-name> # This will be the package name of your CDN
-What should be the name of the app? <NAME>.wasmer.app: <your-app-name> # This will be the name of your app
-Would you like to publish the app now? no # Select no for now
-Writing app config to '/path/to/your/project/app.yaml'
-To (re)deploy your app, run 'wasmer deploy'
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · static-website
+✔ What would you like to deploy? · Start with a template
+✔ Select a language (6 available) · N/A
+✔ Selected template · CDN Starter - demo url https://cdn-wasmer-starter.wasmer.app/
+✔ Unpacked template
+✔ Do you want to deploy the app now? · no
 ```
+The prompt may vary depending depending on wasmer runtime version, look for the CDN starter.
 
-Select the above configuration mentioned in the comments and press enter.
-
-The above command will initialize a blank project with the following structure.
-
-<FileTree>
-  <FileTree.Folder name="your-top-level-dir" defaultOpen>
-    <FileTree.Folder name="public" defaultOpen>
-      <FileTree.File name="index.html" />
-    </FileTree.Folder>
-    <FileTree.File name="app.yaml" />
-    <FileTree.File name="wasmer.toml" />
-  </FileTree.Folder>
-</FileTree>
-
-### Changing configuration for the CDN
-
-As you might notice, this project uses the `static-web-server` package which is a static web server written in Rust.
-
-Most notably, it supports changing the compression level, cache control, cors, and more.
-All these configurations can be super useful when configuring a CDN.
-
-So, let's add a `config.toml` file in your top level directory for `static-web-server`'s configuration.
-
-```toml
-[general]
-
-#### Address & Root dir
-host = "::"
-port = 8080
-root = "/app/public" # 👈🏼 Change the root directory to the public directory for static assets
-```
-
-<Callout type="info" emoji="ℹ️">
-  The above configuration is the default configuration of the
-  `static-web-server` package. More info about it can be found
-  [here](https://static-web-server.net/configuration/config-file/).
-</Callout>
-
-Now, let's add the following configuration to the `wasmer.toml` file.
-
-```yaml
-[package]
-name = "<your-namespace>/<your-app-name>"
-version = "0.1.0"
-description = "<your-namespace>/<your-app-name> CDN on Wasmer Edge"
-
-[dependencies]
-"wasmer/static-web-server" = "^1"
-
-[fs]
-"/app" = "." # 👈🏼 Add the app directory as a volume mapping it to the root directory
-
-[[command]]
-name = "script"
-module = "wasmer/static-web-server:webserver"
-runner = "https://webc.org/runner/wasi"
-
-[command.annotations.wasi] # 👈🏼 Add config.toml as an argument for the webserver
-main-args = ["-w", "/app/config.toml"]
-```
-
-### Adding files for hosting
-
-By default the static website template generates a `public/index.html`, we can remove it if we don't need it (`rm public/index.html`).
-
-And now, let's add some images in our `public` directory to host. I'll be using some free images from [unsplash](https://unsplash.com/).
-
-This is how the directory structure looks like now:
+The above command will initialize a project with the following structure.
 
 <FileTree>
   <FileTree.Folder name="your-top-level-dir" defaultOpen>
@@ -127,8 +55,13 @@ This is how the directory structure looks like now:
       <FileTree.File name="image2.jpg" />
       <FileTree.File name="image3.jpg" />
     </FileTree.Folder>
+    <FileTree.Folder name="settings" defaultOpen>
+      <FileTree.File name="config.toml" />
+    </FileTree.Folder>
     <FileTree.File name="app.yaml" />
     <FileTree.File name="wasmer.toml" />
+    <FileTree.File name="LICENSE" />
+    <FileTree.File name="README.md" />
   </FileTree.Folder>
 </FileTree>
 
@@ -142,50 +75,45 @@ You can also add other files like css, js, videos, pdfs, etc.
 
 Now, let's deploy the app.
 
-```bash
-$ wasmer deploy
+```bash copy
+wasmer deploy
 ```
 
 The above command will prompt you with the following:
 
 ```bash
-Loaded app from: /path/to/your/dir/app.yaml
+Loading local package (manifest path: /tmp/tmp.61AOVENLwX/.)
+✔ Correctly built package locally
+✔ Package correctly uploaded
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+Deploying app static-website (wasmer-user) to Wasmer Edge...
 
-Publish new version of package '<your-namespace>/<your-app-name>'? yes
-Publishing package...
-[1/2] ⬆️   Uploading...
-[2/2] 📦  Publishing...
-Successfully published package `<your-namespace>/<your-app-name>@0.1.0`
-Waiting for package to become available.....
-Package '<your-namespace>/<your-app-name>@0.1.0' published successfully!
+App static-website (wasmer-user) was successfully deployed 🚀
+https://static-website-wasmer-user.wasmer.app
 
-Deploying app <your-namespace>-<your-app-name>...
-
- ✅ App <your-namespace>/<your-namespace>-<your-app-name> was successfully deployed!
-
-> App URL: https://wasmer-edge-as-cdn.wasmer.app
-> Versioned URL: https://rogh5izceeq4.id.wasmer.app
-> Admin dashboard: https://wasmer.io/apps/wasmer-edge-as-cdn
+→ Unique URL: https://rogh5izc8j9o.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/static-website
 
 Waiting for new deployment to become available...
 (You can safely stop waiting now with CTRL-C)
 .
-New version is now reachable at https://wasmer-edge-as-cdn.wasmer.app
-Deployment complete
+𖥔 Deployment complete
 ```
 
+And it's done!
+The files you've put into the `./public` directory is now accessible from anywhere, at blazing fast speeds!
+
 <Callout type="info" emoji="ℹ️">
-  And now you can view your Static files at the URL mentioned above. You can
-  also view the admin dashboard of your CDN by visiting the URL mentioned above.
+  And now you can view your Static files at the URL mentioned in the deployment output.
+  You can also view the admin dashboard of your CDN by visiting the URL mentioned in the deployment output.
 </Callout>
 
 <Callout type="info" emoji="🌐">
-  You'll need to do `wasmer deploy` again if you add any new files to the
-  `public` directory.
+  You'll need to do `wasmer deploy` again if you add any new files to the `public` directory.
 </Callout>
 
-<Callout type="warning" emoji="🚧">
-  The url of your project will be different from the one mentioned above.
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
 </Callout>
 
 ### Accessing the files
@@ -204,6 +132,32 @@ The same goes for other files as well.
 https://wasmer-edge-as-cdn.wasmer.app/image2.jpg
 https://wasmer-edge-as-cdn.wasmer.app/image3.jpg
 ```
+
+
+### Magic..! 🧙 How does it work?
+
+Have a look inside your local `wasmer.toml` file, here you'll find how the CDN is setup: 
+```toml filename="wasmer.toml"
+[dependencies]
+"wasmer/static-web-server" = "^1"
+
+[fs]
+"/public" = "public" # <-- Here the CDN files are being copied
+"/settings" = "settings"
+
+[[command]]
+name = "script"
+module = "wasmer/static-web-server:webserver" # <-- Here the module to run is being selected
+runner = "https://webc.org/runner/wasi"
+
+[command.annotations.wasi]
+main-args = ["-w", "/settings/config.toml"] # <-- Here the static webserver is being configured
+```
+
+> Aha..! But a static webserver isn't a CDN..!
+
+Wasmer Edge has dynamically distributed workers globally with replicated state.
+This in combination with a fast and efficient webserver will serve data all over the world at minimal latency.
 
 </Steps>
 

--- a/pages/edge/guides/js-wintercg.mdx
+++ b/pages/edge/guides/js-wintercg.mdx
@@ -28,7 +28,8 @@ mkdir my-new-js-worker
 cd my-new-js-worker
 ```
 
-Then, running a single command, we can setup a static website.
+Then, running a single command, we can setup a js worker:
+
 ```bash copy
 wasmer deploy --template=js-worker
 ```
@@ -74,7 +75,7 @@ curl https://jsworker-wasmer-user.wasmer.app
 ```
 
 <Callout type="info" emoji="ℹ">
-    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
 </Callout>
 
 Expect output similar to:
@@ -111,7 +112,7 @@ async function handler(request) {
   const out = JSON.stringify({
     env: process.env,
     headers: Object.fromEntries(request.headers),
-    hello: "world", // <- Add this
+    hello: "world", // 👈 Add this
   }, null, 2);
   return new Response(out, {
     headers: { "content-type": "application/json" },

--- a/pages/edge/guides/js-wintercg.mdx
+++ b/pages/edge/guides/js-wintercg.mdx
@@ -17,32 +17,45 @@ Javascript worker, and deploying it.
 
 <Install />
 
+<Login />
+
 <CliVersionCallout />
 
-### Initialize the local directory 
-With the CLI installed, let's create a new JS service worker! We begin 
-creating a new empty directory - after that, we will need to run a single command. 
+### Deploy!
+We begin creating a new empty directory.
+```bash copy
+mkdir my-new-js-worker
+cd my-new-js-worker
+```
 
+Then, running a single command, we can setup a static website.
+```bash copy
+wasmer deploy --template=js-worker
+```
+This will prompt you for the following:
+
+- **App owner**: This is the owner of the app.
+It can be your username or an organization; if you're logged in, the command will prompt you tochoose from your namespaces: by default, it will be your username.
+- **App name**: This is the name of your app. By default, it will be the name of the current directory. 
+
+Expect to see output similar to this:
 ```bash
-$ mkdir my-js-worker 
-$ cd my-js-worker
-$ wasmer deploy --template=js-worker
 It seems you are trying to create a new app!
-✔ Who should own this app? · <you> 
-✔ What should be the name of the app? · <your-app-name> 
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · jsworker
 ✔ Unpacked template
 ✔ Do you want to deploy the app now? · yes
-Loading local package (manifest path: <current-working-directory>)
+Loading local package (manifest path: ~/wasmer-user/Projects/jsworker/.)
 ✔ Correctly built package locally
 ✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+Deploying app jsworker (wasmer-user) to Wasmer Edge...
 
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
+App jsworker (wasmer-user) was successfully deployed 🚀
+https://jsworker-wasmer-user.wasmer.app
 
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
+→ Unique URL: https://48xhpiqcq3mg.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/jsworker
 
 Waiting for new deployment to become available...
 (You can safely stop waiting now with CTRL-C)
@@ -50,23 +63,30 @@ Waiting for new deployment to become available...
 𖥔 Deployment complete
 ```
 
-The `wasmer deploy --template=js-worker` command will prompt you for the following:
-
-- **App owner**: This is the owner of the app. It can be your username
-  or an organization; if you're logged in, the command will prompt you to
-  choose from your namespaces: by default, it will be your username.
-- **App name**: This is the name of your app. By default, it will be the name
-  of the current directory. 
-
 The above command will do the following:
 
 - Download the template from the registry 
-- Deploy it to Wasmer Edge with the user-provided informations
+- Deploy it to Wasmer Edge with the user-provided information
 
 Let's check it: 
-```shell
-$ curl https://<your-app-name>-<you>.wasmer.app
-{"success":true,"package":"wasmer/js-worker-starter"}%   
+```bash copy
+curl https://jsworker-wasmer-user.wasmer.app
+```
+
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+</Callout>
+
+Expect output similar to:
+```bash
+{
+  "env": {
+    ...
+  },
+  "headers": {
+    ...
+  }
+}
 ```
 
 ### Update the app 
@@ -81,16 +101,18 @@ Your directory should now look like this:
   <FileTree.File name="app.yaml" />
 </FileTree>
 
+
+
 To illustrate the lifecycle of an app, let's edit the `index.js` file 
 in the `public` folder: 
 
 ```js copy filename="src/index.js"
 async function handler(request) {
   const out = JSON.stringify({
-	hello: "world", 	// <- New line 
-    success: true,
-    package: "wasmer/js-worker-starter",
-  });
+    env: process.env,
+    headers: Object.fromEntries(request.headers),
+    hello: "world", // <- Add this
+  }, null, 2);
   return new Response(out, {
     headers: { "content-type": "application/json" },
   });
@@ -98,53 +120,63 @@ async function handler(request) {
 
 addEventListener("fetch", (fetchEvent) => {
   fetchEvent.respondWith(handler(fetchEvent.request));
-});
+}
 ```
 
 Now, simply run `wasmer deploy` again:
-```shell
-$ wasmer deploy
-Loading local package (manifest path: <current-working-directory>)
-✔ Correctly built package locally
-✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
-
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
-
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
-
-Waiting for new deployment to become available...
-(You can safely stop waiting now with CTRL-C)
-.
-𖥔 Deployment complete
+```bash copy
+wasmer deploy
 ```
 
-Let's check it again:
-```shell
-$ curl https://<your-app-name>-<you>.wasmer.app
-{"hello": "world", "success":true,"package":"wasmer/js-worker-starter"}%   
+Wait for the deployment to be ready, then check it again:
+```bash copy
+curl https://jsworker-wasmer-user.wasmer.app
+```
+
+Expect output:
+```bash
+{
+  "env": {
+    ...
+  },
+  "headers": {
+    ...
+  },
+  "hello": "world"
+}
 ```
 
 ### Testing your JS service worker locally
 
 To run your worker locally, simply run
 
-```shell copy
-$ wasmer run .
-2023-10-05T09:46:19.513568Z  INFO wasmer_winter: starting webserver
-2023-10-05T09:46:19.514089Z  INFO wasmer_winter::server: starting server on 0.0.0.0:8080 listen=0.0.0.0:8080
+```bash copy
+wasmer run .
 ```
+
+<Callout type="info" emoji="ℹ️">
+  You can see all the available options with `wasmer run --help` or click [here](/runtime/cli/) to see the full documentation. 
+</Callout>
 
 The above command will start a web server on `http://127.0.0.1:8080`.
 
 Let's try to cURL the server:
 
-```shell copy
-$ curl http://127.0.0.1:8080
-{"success":true,"package":"wasmer/js-service-worker"}
+```bash copy
+curl http://127.0.0.1:8080
+```
+
+Expect:
+```bash
+{
+  "env": {
+    ...
+  },
+  "headers": {
+    ...
+  },
+  "hello": "world"
+}
 ```
 
 </Steps>
@@ -155,6 +187,15 @@ Congratulations! You have successfully deployed a JS service worker on Wasmer Ed
 
 > Tip: To make changes to your JS service worker, simply modify the `index.js` file in the
 > `src` directory and run `wasmer deploy` again to deploy the changes.
+
+### Following up
+Try running:
+```bash copy
+time curl -o /dev/null -s -w '%{time_total}\n' https://<app-name>-<your-user>.wasmer.app
+```
+
+Note how the cold-start isn't so cold! 🔥
+Compare this to some of [the alternatives](/edge/vs/amazon-lambda).
 
 
 ### Resources

--- a/pages/edge/guides/laravel.mdx
+++ b/pages/edge/guides/laravel.mdx
@@ -5,24 +5,25 @@ import Login from "@components/login.mdx";
 import GitHubLogo from "@components/GitHubLogo.tsx";
 import CliVersionCallout from "@components/deploy/CliVersionCallout.mdx";
 
-
-Getting an application running on Wasmer Edge is essentially working out how to package it as a deployable image. Once packaged, it can be deployed to the [Wasmer Edge](https://wasmer.io/products/edge) platform.
+Getting an application running on Wasmer Edge is essentially working out how to package it as a deployable image.
+Once packaged, it can be deployed to the [Wasmer Edge](https://wasmer.io/products/edge) platform.
 
 In this guide we'll learn how to deploy a Laravel application on Wasmer Edge.
 You can also set up a new app easily with the [Laravel template for Wasmer Edge](https://staging.wasmer.io/templates/laravel-starter).
 
+### Prerequisites
+
+* PHP 8.2+ - See instructions [here](https://www.php.net/manual/en/install.php)
+* composer - See instructions [here](https://getcomposer.org/download/)
 
 ## Prepare a Laravel app
 
 Bring your own Laravel app, or create a new one!
 
-If you want to start fresh, here's how to set up a new application.
-You'll need PHP 8+ and composer installed locally. You can check your PHP version using `php --version`.
-
-```bash
-$ composer create-project laravel/laravel wasmer-edge-laravel
-$ cd wasmer-edge-laravel
-$ php artisan serve
+```bash copy
+composer create-project laravel/laravel wasmer-edge-laravel
+cd wasmer-edge-laravel
+php artisan serve
 ```
 
 You should be able to visit http://localhost:8000 and see the home page.
@@ -32,6 +33,8 @@ You should be able to visit http://localhost:8000 and see the home page.
 <Steps>
 
 <Install />
+
+<Login />
 
 ### Setup a Wasmer Package
 
@@ -55,8 +58,8 @@ main-args = ["-t", "/app/public", "-S", "localhost:8080"]
 
 You can test that the app works properly with Wasmer by running in your shell:
 
-```bash
-$ wasmer run .
+```bash copy
+wasmer run .
 ```
 
 And then visiting http://localhost:8080/

--- a/pages/edge/guides/php.mdx
+++ b/pages/edge/guides/php.mdx
@@ -16,39 +16,54 @@ We will cover installation of the CLI, setting up a new PHP application, and dep
 
 <Install />
 
+<Login />
+
 <CliVersionCallout />
 
-### Initialize the local directory 
+### Deploy!
 
-With the CLI installed, let's create a new PHP application! We begin 
-creating a new empty directory - after that, we will need to run a single command. 
+We begin creating a new empty directory.
+```bash copy
+mkdir my-new-php-app
+cd my-new-php-app
+```
 
+Then, running a single command, we can setup a php application.
+```bash copy
+wasmer deploy --template=php-starter
+```
+
+This will prompt you for the following:
+
+- **App owner**: This is the owner of the app.
+It can be your username or an organization; if you're logged in, the command will prompt you tochoose from your namespaces: by default, it will be your username.
+- **App name**: This is the name of your app. By default, it will be the name of the current directory. 
+
+Expect to see output similar to this:
 ```bash
-$ mkdir my-php-application && cd my-php-application
-$ wasmer deploy --template=php-starter
+It seems you are trying to create a new app!
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · php-starter
+✔ Select the directory to save the app in · php-starter
+✔ Unpacked template
+✔ Do you want to deploy the app now? · yes
+Loading local package (manifest path: php-starter/.)
+✔ Correctly built package locally
+✔ Package correctly uploaded
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+Deploying app php-starter (wasmer-user) to Wasmer Edge...
+
+App php-starter (wasmer-user) was successfully deployed 🚀
+https://php-starter-wasmer-user.wasmer.app
+
+→ Unique URL: https://2e5h6i7cd9ql.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/php-starter
+
+Waiting for new deployment to become available...
+(You can safely stop waiting now with CTRL-C)
+.
+𖥔 Deployment complete
 ```
-
-The `wasmer deploy --template=php-starter` command will prompt you for the following:
-
-- Download the PHP template from the registry 
-- Deploy it to Wasmer Edge with the user-provided informations
-  - **App owner**: This is the owner of the app. It can be your username
-    or an organization; if you're logged in, the command will prompt you to
-    choose from your namespaces: by default, it will be your username.
-  - **App name**: This is the name of your app. By default, it will be the name
-    of the current directory. 
-
-Let's check it: 
-```shell
-$ curl https://<your-app>.wasmer.app
-1	=>	PHP code tester Sandbox Online
-emoji	=>	😀 😃 😄 😁 😆
-2	=>	5
-5	=>	89009
-Random number	=>	<random!>
-PHP Version	=>	8.3.4
-```
-
 
 Your directory should now look like this:
 
@@ -61,6 +76,80 @@ Your directory should now look like this:
   <FileTree.File name="app.yaml" />
   <FileTree.File name="wasmer.toml" />
 </FileTree>
+
+Let's check it: 
+```bash copy
+curl https://php-starter-wasmer-user.wasmer.app
+```
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+</Callout>
+
+Expect output similar to this:
+```bash
+1       =>      PHP code tester Sandbox Online
+emoji   =>      😀 😃 😄 😁 😆
+2       =>      5
+5       =>      89009
+Random number   =>      630
+PHP Version     =>      8.3.4
+```
+
+### Update the app 
+
+To illustrate the lifecycle of an app, let's edit the `index.php` file 
+in the `app` folder: 
+
+```php copy filename="app/index.php"
+<?php 
+  echo 'Hello World!';   
+  var_dump($_SERVER); 
+?>
+```
+
+Now, simply run `wasmer deploy` again:
+
+```bash copy
+wasmer deploy
+```
+
+Let's check it again:
+```bash copy
+curl https://php-starter-wasmer-user.wasmer.app
+```
+
+Expect to see:
+```bash
+Hello World!array(19) {
+  ...
+}
+```
+
+
+### Testing your PHP application locally
+To test your PHP application locally simply run
+
+```bash copy
+wasmer run .
+```
+
+<Callout type="info" emoji="ℹ️">
+  You can see all the available options with `wasmer run --help` or click  [here](/runtime/cli/) to see the full documentation. 
+</Callout>
+
+
+Let's try to cURL the server:
+
+```bash copy
+curl http://127.0.0.1:8080
+```
+
+Expect to see:
+```bash
+Hello World!array(19) {
+  ...
+}
+```
 
 ### Custom PHP settings 
 
@@ -92,8 +181,7 @@ upload_max_filesize = "20M"
 post_max_size = "25M"
 ```
 
-Now, mount the `config` directoy inside of the filesystem (`fs`) in `wasmer.toml`, and set the
-environment variable `PHPRC`
+Now, copy the `config` directory inside of the filesystem (`fs`) in `wasmer.toml`, and set the environment variable `PHPRC`
 
 ```toml filename="wasmer.toml" /config/ /PHPRC/
 [fs]
@@ -119,7 +207,7 @@ The `main-args` current values are equivalent to calling `php -t app -S localhos
 If you want to accelerate the cold-start times of your PHP app (for example, if you are using Symfony or Laravel with tons of PHP imports), Instaboot can help to
 speed up cold-starts by 100-200x.
 
-```yaml filename="app.yaml"
+```yaml filename="app.yaml" copy
 capabilities:
   instaboot:
     # We provide a list of HTTP requests that will be used to pre-warm the
@@ -132,58 +220,6 @@ capabilities:
 Learn more about Instaboot [in our docs](/edge/learn/instaboot).
 
 
-### Update the app 
-
-To illustrate the lifecycle of an app, let's edit the `index.php` file 
-in the `app` folder: 
-
-```php copy filename="app/index.php"
-<?php 
-  echo 'Hello World!';   
-  var_dump($_SERVER); 
-?>
-```
-
-Now, simply run `wasmer deploy` again:
-
-```shell
-$ wasmer deploy
-[...]
-𖥔 Deployment complete
-```
-
-Let's check it again:
-```shell
-$ curl https://<your-app>.wasmer.app
-Hello World! <more text..>
-```
-
-### Testing your PHP application locally
-To test your PHP application locally simply run
-
-```shell copy
-$ wasmer run .
-Starting server on http://127.0.0.1:8000
-````
-
-<Callout type="info" emoji="ℹ️">
-  You can see all the available options with `wasmer run --help` or click
-  [here](/runtime/cli/) to see the full documentation. 
-</Callout>
-
-
-Let's try to cURL the server:
-
-```shell copy
-$ curl http://127.0.0.1:8000
-1	=>	PHP code tester Sandbox Online
-emoji	=>	😀 😃 😄 😁 😆
-2	=>	5
-5	=>	89009
-Random number	=>	286
-PHP Version	=>	8.3.4
-Hello	=>	World
-```
 
 </Steps>
 

--- a/pages/edge/guides/php.mdx
+++ b/pages/edge/guides/php.mdx
@@ -82,7 +82,7 @@ Let's check it:
 curl https://php-starter-wasmer-user.wasmer.app
 ```
 <Callout type="info" emoji="ℹ">
-    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
 </Callout>
 
 Expect output similar to this:

--- a/pages/edge/guides/python-flask-server.mdx
+++ b/pages/edge/guides/python-flask-server.mdx
@@ -21,19 +21,14 @@ We'll be deploying a basic flask server with default index endpoint.
 
 ### Initialize the Python Application Starter template
 
-```shell copy
-$ wasmer app create
-App type:
-  Static website
-  HTTP server
-  Browser shell
-  JS Worker (experimental)
-> Python Application
+```bash copy
+wasmer app create
 ```
 
+Then follow the CLI and select some of the alternatives which creates a python app.
+
 <Callout type="info" emoji="ℹ️">
-  This is an interactive command. You can also use the `--type` flag to specify
-  the app type.
+  This is an interactive command. You can also use the `--template` flag to specify the app type.
 </Callout>
 
 Further you will be prompted to enter your package name and app name. You can choose any name you like.
@@ -54,8 +49,8 @@ You directory composition should look like this:
 
 ### Configure the Python Virtual Environment
 
-```shell copy
-$ python -m venv .env
+```bash copy
+python -m venv .env
 ```
 
 You directory composition should look like this with `.env` folder added:
@@ -71,21 +66,21 @@ You directory composition should look like this with `.env` folder added:
 
 ### Activate the Python Virtual Environment
 
-```shell copy
-$ source .env/bin/activate
+```bash copy
+source .env/bin/activate
 ```
 
 ### Install the Python Flask package
 
-```shell copy
-$ pip install flask
+```bash copy
+pip install flask
 ```
 
 ### Writing the Python Flask Application
 
-Modify the `main.py` file to look like this:
+Modify the `src/main.py` file to look like this:
 
-```python
+```python copy filename="src/main.py"
 from flask import Flask
 
 app = Flask(__name__)
@@ -99,20 +94,25 @@ You can change the return string to anything you like.
 
 ### Test the flask application locally
 
-```shell copy
-$ python -m flask --app /src/main run --debug --no-reload
- * Serving Flask app './src/main'
- * Debug mode: on
+```bash copy
+python -m flask --app src/main run --debug --no-reload
+```
+
+Expect output similar to this:
+```
+* Serving Flask app 'src/main'
+* Debug mode: on
 WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
  * Running on http://127.0.0.1:5000
 Press CTRL+C to quit
+127.0.0.1 - - [13/Jan/2025 14:33:11] "GET / HTTP/1.1" 200 -
 ```
 
 ### Configure the `wasmer.toml` and `app.yaml` files
 
 In our `wasmer.toml` we need to set up some `args` and `env` variables.
 
-```toml
+```toml copy filename="wasmer.toml"
 [package]
 name = "wasmer/python-flask-server"
 version = "0.1.1"
@@ -146,7 +146,7 @@ env = ["PYTHONEXECUTABLE: /bin/python"] # This is the path to the python executa
 
 In our `app.yaml` we want to provide the same args as we did in the `wasmer.toml` file.
 
-```yaml
+```yaml copy filename="app.yaml"
 ---
 kind: wasmer.io/App.v0
 name: wasmer-python-flask-server-myapp-example
@@ -165,21 +165,25 @@ env:
 
 Now, we can test if our application runs with wasmer
 
-```shell copy
-$ wasmer run .
- * Serving Flask app '/src/main'
- * Debug mode: on
-WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
- * Running on http://127.0.0.1:5000
-Press CTRL+C to quit
+```bash copy
+wasmer run .
+```
+
+Expect output similar to:
+```
+
 ```
 
 The above command will start a web server on `http://127.0.0.1:5000`.
 
 Let's try to cURL the server:
 
-```shell copy
-$ curl http://127.0.0.1:5000
+```bash copy
+curl http://127.0.0.1:5000
+```
+
+Expect to see:
+```
 Hello, from Wasmer Edge 🚀
 ```
 
@@ -187,8 +191,12 @@ Hello, from Wasmer Edge 🚀
 
 Deploying is the easiest part. Just run the following command:
 
-```shell copy
-$ wasmer deploy
+```bash copy
+wasmer deploy
+```
+
+Expect to see something like:
+```
 Loaded app from: /.../wasmer-edge/python-flask/app.yaml
 Deploying app wasmer-python-flask-server-myapp-example...
 
@@ -205,8 +213,7 @@ Waiting for new deployment to become available...
 Now you can visit the URL and see your application running on Wasmer Edge.
 
 <Callout type="info" emoji="ℹ️">
-  You must be in the directory holding the `wasmer.toml` and `app.yaml` config
-  files.
+  You must be in the directory holding the `wasmer.toml` and `app.yaml` config files.
 </Callout>
 
 <Callout type="transparent" emoji="💁">

--- a/pages/edge/guides/python-flask-server.mdx
+++ b/pages/edge/guides/python-flask-server.mdx
@@ -25,10 +25,10 @@ We'll be deploying a basic flask server with default index endpoint.
 wasmer app create
 ```
 
-Then follow the CLI and select some of the alternatives which creates a python app.
+Then follow the CLI and select some of the alternatives which creates a **python flask app**.
 
 <Callout type="info" emoji="ℹ️">
-  This is an interactive command. You can also use the `--template` flag to specify the app type.
+  This is an interactive command. You can also use the `--template` flag to specify a template.
 </Callout>
 
 Further you will be prompted to enter your package name and app name. You can choose any name you like.
@@ -108,6 +108,17 @@ Press CTRL+C to quit
 127.0.0.1 - - [13/Jan/2025 14:33:11] "GET / HTTP/1.1" 200 -
 ```
 
+Let's try to cURL the server:
+
+```bash copy
+curl http://127.0.0.1:5000
+```
+
+Expect to see:
+```
+Hello, from Wasmer Edge 🚀
+```
+
 ### Configure the `wasmer.toml` and `app.yaml` files
 
 In our `wasmer.toml` we need to set up some `args` and `env` variables.
@@ -169,14 +180,9 @@ Now, we can test if our application runs with wasmer
 wasmer run .
 ```
 
-Expect output similar to:
-```
-
-```
-
 The above command will start a web server on `http://127.0.0.1:5000`.
 
-Let's try to cURL the server:
+Let's try to cURL the server, running using wasmer:
 
 ```bash copy
 curl http://127.0.0.1:5000

--- a/pages/edge/guides/python.mdx
+++ b/pages/edge/guides/python.mdx
@@ -76,7 +76,7 @@ curl https://python-http-server-wasmer.user.app
 ```
 
 <Callout type="info" emoji="ℹ">
-    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
 </Callout>
 
 Expect output similar to this:

--- a/pages/edge/guides/python.mdx
+++ b/pages/edge/guides/python.mdx
@@ -17,33 +17,47 @@ We will cover installation of the CLI, setting up a new Python HTTP server, and 
 
 <Install />
 
+<Login />
+
 <CliVersionCallout />
 
-### Initialize the local directory 
+### Deploy!
 
-With the CLI installed, let's create a new Python application! We begin 
-creating a new empty directory - after that, we will need to run a single command. 
+We begin creating a new empty directory.
+```bash copy
+mkdir my-new-python-app
+cd my-new-python-app
+```
 
+Then, running a single command, we can setup a python http server.
+```bash copy
+wasmer deploy --template=python-http-server
+```
+
+This will prompt you for the following:
+
+- **App owner**: This is the owner of the app.
+It can be your username or an organization; if you're logged in, the command will prompt you tochoose from your namespaces: by default, it will be your username.
+- **App name**: This is the name of your app. By default, it will be the name of the current directory. 
+
+Expect to see output similar to this:
 ```bash
-$ mkdir my-python-http-server 
-$ cd my-python-http-server
-$ wasmer deploy --template=python-http-server             
 It seems you are trying to create a new app!
-✔ Who should own this app? · <you> 
-✔ What should be the name of the app? · <your-app-name> 
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · python-http-server
 ✔ Unpacked template
 ✔ Do you want to deploy the app now? · yes
-Loading local package (manifest path: <current-working-directory>)
+Loading local package (manifest path: /tmp/tmp.hHSLc0Lr49/.)
 ✔ Correctly built package locally
 ✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+Deploying app python-http-server (wasmer-user) to Wasmer Edge...
 
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
+App python-http-server (wasmer-user) was successfully deployed 🚀
+https://python-http-server-wasmer-user.wasmer.app
 
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
+→ Unique URL: https://r3dhkilce6k0.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/python-http-server
 
 Waiting for new deployment to become available...
 (You can safely stop waiting now with CTRL-C)
@@ -51,23 +65,23 @@ Waiting for new deployment to become available...
 𖥔 Deployment complete
 ```
 
-The `wasmer deploy --template=python-http-server` command will prompt you for the following:
-
-- **App owner**: This is the owner of the app. It can be your username
-  or an organization; if you're logged in, the command will prompt you to
-  choose from your namespaces: by default, it will be your username.
-- **App name**: This is the name of your app. By default, it will be the name
-  of the current directory. 
-
 The above command will do the following:
 
 - Download the template from the registry 
 - Deploy it to Wasmer Edge with the user-provided informations
 
 Let's check it: 
-```shell
-$ curl https://<your-app-name>-<you>.wasmer.app
-{"message": "Python app is running with Wasmer!"}% 
+```bash copy
+curl https://python-http-server-wasmer.user.app
+```
+
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+</Callout>
+
+Expect output similar to this:
+```bash
+{"message": "Python app is running with Wasmer!"}
 ```
 
 ### Update the app 
@@ -118,53 +132,42 @@ if __name__ == "__main__":
 
 Let's re-deploy our Python HTTP server:
 
-```shell
-$ wasmer deploy
-Loading local package (manifest path: <current-working-directory>)
-✔ Correctly built package locally
-✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
-
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
-
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
-
-Waiting for new deployment to become available...
-(You can safely stop waiting now with CTRL-C)
-.
-𖥔 Deployment complete
+```bash copy
+wasmer deploy
 ```
 
-Let's try to cURL the server:
+Once it's successfully redeployed, let's try to cURL the server:
 
-```shell copy
-$ curl https://<your-app-name>-<you>.wasmer.app
-{"message": "Python app is running with Wasmer!", "hello": "world"}% 
+```bash copy
+curl https://python-http-server-wasmer.user.app
+```
+
+Expect it to contain the additional data field:
+```bash
+{"message": "wasmer/python-http-server is running on Python!", "hello": "world"}
 ```
 
 ### Testing your Python application locally
 
 To run your Python application locally simply run 
-```shell copy
-$ wasmer run . --env PORT=9090
-Starting server on http://127.0.0.1:9090
+```bash copy
+wasmer run . --env PORT=9090
 ``````
 
 This will start a local server on  `http://localhost:9090`.
 
 <Callout type="info" emoji="ℹ️">
-  You can see all the available options with `wasmer run --help` or click
-  [here](/runtime/cli/) to see the full documentation. 
+  You can see all the available options with `wasmer run --help` or click [here](/runtime/cli/) to see the full documentation. 
 </Callout>
 
 Let's try to cURL the server:
 
-```shell copy
-$ curl http://127.0.0.1:9090
-{"message": "Python app is running with Wasmer!"}% 
+```shell
+curl http://127.0.0.1:9090
+```
+Expect:
+```bash
+{"message": "wasmer/python-http-server is running on Python!", "hello": "world"}
 ```
 
 </Steps>

--- a/pages/edge/guides/react-static-site.mdx
+++ b/pages/edge/guides/react-static-site.mdx
@@ -13,7 +13,8 @@ In this guide, you'll learn the process of publishing a static site using react 
 
 The project requires the following tools to be installed on your system:
 
-- [Rust](https://www.rust-lang.org/tools/install)
+- [node](https://nodejs.org/en/download)
+- [pnpm](https://pnpm.io/installation)
 
 ## Deploying a Static Site
 
@@ -25,33 +26,31 @@ The project requires the following tools to be installed on your system:
 
 <Login />
 
-### Step 3.1: Initialize the React Starter template
+### Initialize the React Starter template
 
 <Callout type="info" emoji="ℹ️">
-  If you have already your react project with you, you can skip this step and
-  follow the step 3.2.
+  If you have already your react project with you, you can skip to the next step.
 </Callout>
 
 Clone the starter template from GitHub and install the dependencies:
 
-```shell copy
-$ git clone https://github.com/wasmerio/edge-react-starter.git
-$ cd edge-react-starter
-$ pnpm install
+```bash copy
+git clone https://github.com/wasmerio/edge-react-starter.git
+cd edge-react-starter
+pnpm install
 ```
 
-### Step 3.2: Setup a current react project for Wasmer Edge
+### Setup a current react project for Wasmer Edge
 
 <Callout type="info" emoji="ℹ️">
-  This step is for those who already have a react project with them. If you are
-  starting from scratch, you can follow the step 3.1 to get a boilerplate react
-  project with vite.
+  This step is for those who already have a react project with them.
+    If you are starting from scratch, you can follow the step above to get a boilerplate react project with vite.
 </Callout>
 
 Run the commands below to initialize files for Wasmer Edge:
 
-```shell copy
-$ wasmer app create --type static-website
+```bash copy
+wasmer app create --type static-website
 ```
 
 ```bash
@@ -80,7 +79,7 @@ $ wasmer app create --type static-website
   (You can safely exit now with CTRL-C)
 ```
 
-The `wasmer app create --type static-site` command will prompt you for the following:
+The `wasmer app create --template static-site` command will prompt you for the following:
 
 - **Package owner**: This is the owner of the package. It can be your username or an organization.
 - **Package**: This is the package you want to use. You can either select an existing package or create a new one.
@@ -110,7 +109,7 @@ The above command will do the following:
 >
   ```json
   "scripts": {
-    "build": "vite build -o dist" // 👈🏼 dist or any other directory (keep consistent with wasmer.toml)
+    "build": "tsc && vite build" // 👈🏼 Ensure the build output ends up in the same place as wasmer.toml>fs.public
   }
   ```
 </Callout>
@@ -130,12 +129,12 @@ description = "Your cool react project's description"
 public = "dist" # 👈🏼 dist or any other directory (keep consistent with package.json)
 ```
 
-### Step 4: Test Your Site Locally
+### Test Your Site Locally
 
 You can now test your site locally by running the following command:
 
-```shell copy
-$ wasmer run . -- --port 9000
+```bash copy
+wasmer run . -- --port 9000
 ```
 
 This will start a local server using the Static Web Server on `http://localhost:9000` and now you can access your site on the web at the URL provided in the output.
@@ -147,17 +146,16 @@ You can also specify a different port by changing the `--port` flag.
 > The arguments after `--` are passed to the static web server.
 
 <Callout type="info" emoji="ℹ️">
-  You can see all the available options with `wasmer run --help` or click
-  [here](/runtime/cli/) to see the full documentation. To see all the avilable
-  options for the static web server, run `wasmer run . -- --help`.
+  You can see all the available options with `wasmer run --help` or click [here](/runtime/cli/) to see the full documentation.
+  To see all the available options for the static web server, run `wasmer run . -- --help`.
 </Callout>
 
-### Step 6: Deploy Your Site
+### Deploy Your Site
 
 To deploy your site just build your site and run the following command:
 
-```shell copy
-$ pnpm run build
+```bash copy
+pnpm run build
 ```
 
 Run the following command to deploy your site:
@@ -168,7 +166,7 @@ Once you have added all the necessary files to the public directory, it's time t
 
 Run the following command to deploy your site:
 
-```shell copy
+```bash copy
 wasmer deploy
 ```
 

--- a/pages/edge/guides/react-static-site.mdx
+++ b/pages/edge/guides/react-static-site.mdx
@@ -40,6 +40,13 @@ cd edge-react-starter
 pnpm install
 ```
 
+By now, you should have a react project installed and ready to go.
+Let's build it, in preparation for future steps:
+
+```bash copy
+pnpm run build
+```
+
 ### Setup a current react project for Wasmer Edge
 
 <Callout type="info" emoji="ℹ️">
@@ -50,7 +57,7 @@ pnpm install
 Run the commands below to initialize files for Wasmer Edge:
 
 ```bash copy
-wasmer app create --type static-website
+wasmer app create --template static-site
 ```
 
 ```bash
@@ -152,24 +159,21 @@ You can also specify a different port by changing the `--port` flag.
 
 ### Deploy Your Site
 
-To deploy your site just build your site and run the following command:
+First, we need to build our distribution:
 
 ```bash copy
 pnpm run build
 ```
 
-Run the following command to deploy your site:
-
-### Deploy Your Site
-
 Once you have added all the necessary files to the public directory, it's time to update site.
 
-Run the following command to deploy your site:
+Run the following command to deploy:
 
 ```bash copy
 wasmer deploy
 ```
-
+  
+Expect output similar to this:
 ```shell
 Loaded app from: /path/to/your/directory/app.yaml
 
@@ -195,8 +199,6 @@ Waiting for the app to become reachable...
 App is now reachable!
 ```
 
-> You can checkout our versioned URL above to access how our starter demo looks like.
-
 <Callout type="info" emoji="ℹ️">
   You must be in the directory holding the `wasmer.toml` and `app.yaml` config
   files.
@@ -207,8 +209,6 @@ App is now reachable!
   version. You can check all the available options with `wasmer deploy --help`
   or click [here](/edge/cli) to see the full documentation.
 </Callout>
-
-Executing this command will package and deploy your site.
 
 Now you can access your site on the web at the URL provided in the output.
 

--- a/pages/edge/guides/rust-http-server.mdx
+++ b/pages/edge/guides/rust-http-server.mdx
@@ -31,21 +31,29 @@ The project requires the following tools to be installed on your system:
 With the CLI installed, let's create a new Axum application! We begin 
 creating a new empty directory - after that, we will need to run a single command. 
 
-```bash
-$ mkdir my-axum-server
-$ cd my-axum-server
-$ wasmer deploy --template=axum-starter
-It seems you are trying to create a new app!
-✔ Who should own this app? · <you> 
-✔ What should be the name of the app? · <your-app-name> 
+```bash copy
+mkdir my-axum-server
+cd my-axum-server
+```
 
+Then, let's try to deploy using a axum template:
+
+```bash copy
+wasmer deploy --template=axum-starter
+```
+
+Which should give you output similar to this:
+```bash
+It seems you are trying to create a new app!
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · axum-starter
 ✔ Unpacked template
 
 NOTE: The selected template has a `BUILD.md` file.
-This means there are likely additional build 
+This means there are likely additional build
 steps that you need to perform before deploying
 the app:
- 
+
 # Building the application
 1. Install [WASIX](https://wasix.org/docs/language-guide/rust/installation)
 2. Build the application: `cargo wasix build --release`
@@ -53,13 +61,16 @@ the app:
 After taking the necessary steps to build your application, re-run `wasmer deploy`
 ```
 
-You can see, as prompted by the command, that we'll need a couple more steps
-before deploying the server, namely actually _building_ the application: we
-assume you installed the [`WASIX`](https://wasix.org/docs/language-guide/rust/installation) toolchain. We need to build the HTTP server
-using `cargo wasix`:
+You can see, as prompted by the command, that we'll need a couple more steps before deploying the server, namely actually _building_ the application.
+We assume you installed the [`WASIX`](https://wasix.org/docs/language-guide/rust/installation) toolchain.
+We need to build the HTTP server using `cargo wasix`:
 
+```bash copy
+cargo wasix build --release
 ```
-$ cargo wasix build --release
+
+Expect output like this:
+```
 ...
 Compiling wasmer-hello v0.1.0 (/.../Wasmer/edge-quickstart/wasmer-hello)
 Finished dev [unoptimized + debuginfo] target(s) in 10.69s
@@ -71,6 +82,8 @@ info: Post-processing WebAssembly files
   that needs to be used to achieve WASIX compatibility: one of the easiest
   "gotchas" is forgetting to update your lock file with `cargo update`.
 </Callout>
+
+### Deploy it
 
 Now, Your directory structure should look like this:
 
@@ -91,8 +104,12 @@ Now, Your directory structure should look like this:
 </FileTree>
 
 Once the application itself was correctly built, you can re-run `wasmer deploy`:
-```shell
-$ wasmer deploy 
+```bash copy
+ wasmer deploy 
+```
+
+Expect to see output similar to this:
+```bash copy
 It seems you are trying to create a new app!
 ✔ Who should own this app? · <you> 
 ✔ What should be the name of the app? · <your-app-name> 
@@ -118,8 +135,12 @@ Waiting for new deployment to become available...
 ```
 
 Let's check it:
-```shell
-$ curl https://<your-app-name>-<you>.wasmer.app
+```bash copy
+curl https://<your-app-name>-<you>.wasmer.app
+```
+
+Expect:
+```
 Hello, Axum ❤️ WASIX!
 ```
 

--- a/pages/edge/guides/static-site.mdx
+++ b/pages/edge/guides/static-site.mdx
@@ -76,6 +76,10 @@ If you want to learn how to specify a different directory for build output, chec
 
 Try clicking the URL which is under the deployment message `https://my-new-site-wasmer-user.wasmer.app`, and expect to see something like:
 
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
+</Callout>
+
 <StaticSite image={staticSiteImg} />
 
 ### Update the app 

--- a/pages/edge/guides/static-site.mdx
+++ b/pages/edge/guides/static-site.mdx
@@ -12,6 +12,12 @@ import updatedStaticSiteImg from "@assets/deploy/quickstart/updated-static-site.
 In this quickstart guide, you'll learn the process of deploying a static site on Wasmer Edge.
 We will cover installation of the CLI, setting up a new static site, and deploying it.
 
+<Callout type="default" emoji="⚛">
+  If you want to deploy a static site made from frameworks like React, Vue, or
+  Svelte, you can follow our [React Static
+  Site](/edge/guides/react-static-site) tutorial.
+</Callout>
+
 ## Deploying a static site
 
 <Steps>
@@ -21,68 +27,45 @@ We will cover installation of the CLI, setting up a new static site, and deployi
 <CliVersionCallout />
 
 ### Initialize the local directory 
+We begin creating a new empty directory.
+```bash copy
+mkdir my-new-site
+cd my-new-site
+```
 
-<Callout type="default" emoji="⚛">
-  If you want to deploy a static site made from frameworks like React, Vue, or
-  Svelte, you can follow our [React Static
-  Site](/edge/guides/react-static-site) tutorial.
-</Callout>
+Then, running a single command, we can setup a static website.
+```bash copy
+wasmer deploy --template=static-website             
+```
 
-With the CLI installed, let's create a new static site! We begin 
-creating a new empty directory - after that, we will need to run a single command. 
-
+Expect to see output similar to this:
 ```bash
-$ mkdir my-new-site
-$ cd my-new-site
-$ wasmer deploy --template=static-website             
 It seems you are trying to create a new app!
-✔ Who should own this app? · <you> 
-✔ What should be the name of the app? · <your-app-name> 
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · my-new-site
 ✔ Unpacked template
 ✔ Do you want to deploy the app now? · yes
-Loading local package (manifest path: <current-working-directory>)
+Loading local package (manifest path: ~/wasmer-user/Projects/my-new-site/.)
 ✔ Correctly built package locally
 ✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+Deploying app my-new-site (wasmer-user) to Wasmer Edge...
 
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
+App my-new-site (wasmer-user) was successfully deployed 🚀
+https://my-new-site-wasmer-user.wasmer.app
 
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
+→ Unique URL: https://2dyh6i3cvx1y.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/my-new-site
 
 Waiting for new deployment to become available...
 (You can safely stop waiting now with CTRL-C)
-.
-𖥔 Deployment complete
-```
-
-The `wasmer deploy --template=static-website` command will prompt you for the following:
-
-- **App owner**: This is the owner of the app. It can be your username
-  or an organization; if you're logged in, the command will prompt you to
-  choose from your namespaces: by default, it will be your username.
-- **App name**: This is the name of your app. By default, it will be the name
-  of the current directory. 
+ ```
 
 The above command will do the following:
 
-- Download the template from the registry 
-- Deploy it to Wasmer Edge with the user-provided informations
-
-<Callout type="error" emoji="⚠️">
-  Don't change the `public` directory attribute in the `wasmer.toml` file for
-  this tutorial. If you want to learn how to specify a different directory for
-  build output, check out our [React Static
-  Site](/edge/guides/react-static-site) tutorial.
-</Callout>
-
-This is what the static website looks like in a browser:
-
-<StaticSite image={staticSiteImg} />
-
-### Update the app 
+1. Download the template from the registry 
+1. Store the template locally in your current directory (try running `ls -la`)
+1. Deploy it to Wasmer Edge
 
 Your directory structure should look like this:
 
@@ -101,64 +84,55 @@ Your directory structure should look like this:
   </FileTree.Folder>
 </FileTree>
 
+<Callout type="error" emoji="⚠️">
+Don't change the `public` directory attribute in the `wasmer.toml` file for this tutorial.
+If you want to learn how to specify a different directory for build output, check out our [React Static Site](/edge/guides/react-static-site) tutorial.
+</Callout>
 
-To illustrate the lifecycle of an app, let's edit the `index.html` file 
-in the `public` folder: 
+Try clicking the **Unique URL** that's posted in your terminal output, and expect to see something like:
 
-```shell
-$ pwd
-.../my-new-site
-$ sed -i -e 's/Hi from the Edge/This is our new title!/g' public/index.html 
-$ wasmer deploy
-Loading local package (manifest path: <current-working-directory>)
-✔ Correctly built package locally
-✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace <you> on the registry 
-Deploying app <your-app-name> (<you>) to Wasmer Edge...
+<StaticSite image={staticSiteImg} />
 
-App <your-app-name> (<you>) was successfully deployed 🚀
-https://<your-app-name>-<you>.wasmer.app
 
-→ Unique URL: https://<app_id>.id.wasmer.app
-→ Dashboard:  https://wasmer.io/apps/<you>/<your-app-name>
+### Update the app 
+To illustrate the lifecycle of an app, let's edit the `index.html` file in the `public` folder: 
 
-Waiting for new deployment to become available...
-(You can safely stop waiting now with CTRL-C)
-.
-𖥔 Deployment complete
+```bash copy
+sed -i -e 's/Hi from the Edge/This is our new title!/g' public/index.html 
 ```
 
+Then let's redepoy it:
+```bash copy
+wasmer deploy
+```
+
+When going to/updating the **Unique URL**, expect the page to have been updated:
 <StaticSite image={updatedStaticSiteImg} />
 
 ### Add your content
 
 Currently, the public directory only contains a basic `index.html` file.
 
-You can now modify this directory and copy your own files (HTML, CSS, JavaScript, images, etc)
-as needed.
+You can now modify this directory and copy your own files (HTML, CSS, JavaScript, images, etc) as needed.
 
 ### Test your site locally 
 
-You can also test your site locally before deploying the app on Wasmer Edge by
-running the following command:
+You can also test your site locally before deploying the app on Wasmer Edge by running the following command:
 
 ```shell copy
 wasmer run .
 ```
 
-This will start a local server using the Static Web Server on
-`http://localhost:80`. You can also specify a different port by passing the
-`--port` flag, as in `wasmer run . -- --port=<your-port>`.
+This will start a local server using the Static Web Server on `http://localhost:8080`.
+You can also specify a different port by passing the `--port` flag, as in `wasmer run . -- --port=<your-port>`.
 
 <Callout type="info" emoji="ℹ️">
-  The arguments after `--` (double dash) are passed to the underlying server running in the
-  Wasmer runtime.
+  The arguments after `--` (double dash) are passed to the underlying server running in the Wasmer runtime.
 </Callout>
 
 <Callout type="info" emoji="ℹ️">
-  You can see all the available options with `wasmer run --help` or click
-  [here](/runtime/cli/) to see the full documentation. To see all the avilable
-  options for the static web server, run `wasmer run . -- --help`.
+  You can see all the available options with `wasmer run --help` or click [here](/runtime/cli/) to see the full documentation.
+  To see all the avilable options for the static web server, run `wasmer run . -- --help`.
 </Callout>
 
 </Steps>

--- a/pages/edge/guides/static-site.mdx
+++ b/pages/edge/guides/static-site.mdx
@@ -24,9 +24,11 @@ We will cover installation of the CLI, setting up a new static site, and deployi
 
 <Install />
 
+<Login />
+
 <CliVersionCallout />
 
-### Initialize the local directory 
+### Deploy!
 We begin creating a new empty directory.
 ```bash copy
 mkdir my-new-site
@@ -67,6 +69,18 @@ The above command will do the following:
 1. Store the template locally in your current directory (try running `ls -la`)
 1. Deploy it to Wasmer Edge
 
+<Callout type="error" emoji="⚠️">
+Don't change the `public` directory attribute in the `wasmer.toml` file for this tutorial.
+If you want to learn how to specify a different directory for build output, check out our [React Static Site](/edge/guides/react-static-site) tutorial.
+</Callout>
+
+Try clicking the URL which is under the deployment message `https://my-new-site-wasmer-user.wasmer.app`, and expect to see something like:
+
+<StaticSite image={staticSiteImg} />
+
+### Update the app 
+To illustrate the lifecycle of an app, let's edit the `index.html` file in the `public` folder: 
+
 Your directory structure should look like this:
 
 <FileTree>
@@ -84,29 +98,18 @@ Your directory structure should look like this:
   </FileTree.Folder>
 </FileTree>
 
-<Callout type="error" emoji="⚠️">
-Don't change the `public` directory attribute in the `wasmer.toml` file for this tutorial.
-If you want to learn how to specify a different directory for build output, check out our [React Static Site](/edge/guides/react-static-site) tutorial.
-</Callout>
-
-Try clicking the **Unique URL** that's posted in your terminal output, and expect to see something like:
-
-<StaticSite image={staticSiteImg} />
-
-
-### Update the app 
-To illustrate the lifecycle of an app, let's edit the `index.html` file in the `public` folder: 
+Lets modify index.html:
 
 ```bash copy
 sed -i -e 's/Hi from the Edge/This is our new title!/g' public/index.html 
 ```
 
-Then let's redepoy it:
+Now, let's redeploy it:
 ```bash copy
 wasmer deploy
 ```
 
-When going to/updating the **Unique URL**, expect the page to have been updated:
+When refreshing the browser, expect the page to have been updated:
 <StaticSite image={updatedStaticSiteImg} />
 
 ### Add your content

--- a/pages/edge/guides/volumes.mdx
+++ b/pages/edge/guides/volumes.mdx
@@ -13,14 +13,14 @@ In this tutorial, you will learn how to setup peristent storage for your edge ap
 Lets start with creating an edge application
 
 You can quickstart with an application from one of our templates
-```bash
+```bash copy
 wasmer app create --template static-website
 ```
 
 Now, lets edit `app.yaml` to setup persistent volume
 
 Add
-```yaml
+```yaml copy
 volumes:
   - name: data
     mount: /public/things_i_want_to_persist
@@ -33,8 +33,11 @@ Now, lets re-deploy the app
 wasmer deploy
 ```
 
-After deployment completes, you can open your app's dashboard to see the persistent volume under the storage tab. (e.g. https://wasmer.io/apps/{username}/{appname}/storage). All the data that your application creates under the mounted directory will persist through app crashes, restarts and updates. 
-The volumes are also s3 compatible. You can use any s3 client to retrive and upload data to your bucket
+After deployment completes, you can open your app's dashboard, printed in the deployment status: `-> Dashboard:  https://wasmer.io/apps/...`.
+To see the persistent volume under the storage tab (e.g. https://wasmer.io/apps/{username}/{appname}/storage).
+All the data that your application creates under the mounted directory will persist through app crashes, restarts and updates. 
+The volumes are also s3 compatible.
+You can use any s3 client to retrieve and upload data to your bucket
 
 
 # Accessing volume from outside of your app

--- a/pages/edge/guides/wcgi-on-edge.mdx
+++ b/pages/edge/guides/wcgi-on-edge.mdx
@@ -230,7 +230,7 @@ curl https://hello-cgi-wasmer-user.wasmer.app
 ```
 
 <Callout type="info" emoji="ℹ">
-    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.app`
 </Callout>
 
 ```console

--- a/pages/edge/guides/wcgi-on-edge.mdx
+++ b/pages/edge/guides/wcgi-on-edge.mdx
@@ -42,7 +42,7 @@ The project requires the following tools to be installed on your system:
 
 ### Install the `wasm32-wasi` target:
 
-```bash
+```bash copy
 rustup target add wasm32-wasi
 ```
 
@@ -52,13 +52,13 @@ This will install the `wasm32-wasi` target for the Rust compiler.
 
 We'll initialize an empty rust project using the `cargo` command-line tool.
 
-```bash
-cargo init --bin hello-cgi
+```bash copy
+cargo init --bin hello-cgi && cd hello-cgi
 ```
 
 ### Add the CGI crate
 
-```bash
+```bash copy
 cargo add cgi
 ```
 
@@ -89,15 +89,25 @@ fn handler(request: Request) -> Response {
 
 ```
 
-### Wiring it up with WCGI
 
-We'll use the `wcgi` runner from Wasmer to run our CGI app.
-This wiring up is done automatically by the wasmer runtime and we just need to specify
-the runner.
+### Building the CGI app
 
-```toml copy filename="Cargo.toml"
+As you see above in the source property, in the `module` section. We use the release build in wasm32-wasi target.
+
+```bash copy
+cargo build --release --target wasm32-wasi
+```
+
+This will create a `hello-cgi.wasm` file in the `target/wasm32-wasi/release` directory.
+
+### Wiring it up 
+
+To run this `wcgi` app on wasmer, we first need to create a `wasmer.toml` configuration file.
+Create a new file `wasmer.toml` at root level, and copy the following:
+
+```toml copy filename="wasmer.toml"
 [package]
-name = "<your-namespace>/<your-package-name>"
+name = "<your-namespace>/<your-package-name>" # 👈 Update this
 version = "0.1.0"
 description = "An application sample for WCGI"
 license = "MIT OR Apache-2.0"
@@ -110,37 +120,36 @@ abi = "wasi"
 [[command]]
 name = "server"
 module = "server"
-runner = "https://webc.org/runner/wcgi" # 👈🏼 This is the runner we'll be using
-
-[command.annotations.wasi]
-env = ["SCRIPT_NAME=rust_wcgi"] # This hack is required for now
+runner = "https://webc.org/runner/wcgi" # 👈 This is the runner we'll be using
 
 [command.annotations.wcgi]
 dialect = "rfc-3875" # This is the CGI dialect we'll be using
 ```
 
+
 <Callout type="info" emoji="ℹ️">
   <ol>
     <li>
-      1. `your-namespace`: This is usually your username and also can be your
-      organization name.
+      1. `your-namespace`: This is usually your username and also can be your organization name.
     </li>
     <li>
-      2. `your-package-name`: This is the name of your package that'll be
-      published to the wasmer-registry.
+      2. `your-package-name`: This is the name of your package that'll be published to the wasmer-registry.
     </li>
   </ol>
 </Callout>
 
-### Building the CGI app
+Your project should now look like this:
 
-As you see above in the source property, in the `module` section. We use the release build in wasm32-wasi target.
+<FileTree>
+  <FileTree.Folder name="hello-cgi" defaultOpen>
+	<FileTree.Folder name="src" defaultOpen>
+  	  <FileTree.File name="main.rs" />
+  	</FileTree.Folder>
+    <FileTree.File name="Cargo.toml" />
+    <FileTree.File name="wasmer.toml" />
+  </FileTree.Folder>
+</FileTree>
 
-```bash copy
-cargo build --release --target wasm32-wasi
-```
-
-This will create a `hello-cgi.wasm` file in the `target/wasm32-wasi/release` directory.
 
 ### Running the CGI app
 
@@ -170,73 +179,59 @@ curl -X POST -d "Wasmer" http://localhost:8000
 
 The above command will send a `POST` request with the body `Wasmer` to the server.
 
-```console
+```bash
 Hello, Wasmer!
 ```
 
 ### Deploying the CGI app
 
-For this we need to create a `app.yaml` in the root of the project.
-
-```yaml copy filename="app.yaml"
----
-kind: wasmer.io/App.v0
-name: <your-app-name> # 👈🏼 This is the name of your app
-package: <your-namespace>/<your-package-name> # 👈🏼 This is the name of your package that you set above
-```
-
-This would be the final directory structure that you'll see:
-
-<FileTree>
-  <FileTree.Folder name="your-top-level-dir" defaultOpen>
-    <FileTree.Folder name="src" defaultOpen>
-      <FileTree.File name="main.rs" />
-    </FileTree.Folder>
-    <FileTree.File name="Cargo.toml" />
-    <FileTree.File name="app.yaml" />
-    <FileTree.File name="wasmer.toml" />
-  </FileTree.Folder>
-</FileTree>
-
-Now write the following command to deploy the app.
+In order to deploy the app, all we need to do is to run:
 
 ```bash copy
 wasmer deploy
 ```
 
-```console
-Loaded app from: /Volumes/Work/Projects/wasmer-edge/wcgi-rust-template/app.yaml
+This will tigger a wizard which sets up the remaining configuration needed, similar to this:
+```bash
+It seems you are trying to create a new app!
+✔ Who should own this app? · wasmer-user
+✔ What should be the name of the app? · hello-cgi
+A package manifest was found in path /tmp/tmp.bDul0Ng4o3/hello-cgi/wasmer.toml.
+✔ Use it for the app? · yes
+✔ Do you want to deploy the app now? · yes
+Loading local package (manifest path: /tmp/tmp.bDul0Ng4o3/hello-cgi/.)
+✔ Correctly built package locally
+✔ Package correctly uploaded
+✔ Succesfully pushed release to namespace wasmer-user on the registry
+✔ Successfully tagged package wasmer-user/wcgi-hello@0.1.0
+Deploying app hello-cgi (wasmer-user) to Wasmer Edge...
 
-Publish new version of package '<your-namespace>/<your-package-name>'? yes # 👈🏼 choose yes here
-Publishing package...
-[1/2] ⬆️   Uploading...
-[2/2] 📦  Publishing...
-Successfully published package `<your-namespace>/<your-package-name>@0.1.0`
-Waiting for package to become available.......
-Package 'wasmer/wcgi-rust-template@0.1.17' published successfully!
+App hello-cgi (wasmer-user) was successfully deployed 🚀
+https://hello-cgi-wasmer-user.wasmer.app
 
-Deploying app <your-app-name>...
-
- ✅ App <your-namespace>/<your-app-name> was successfully deployed!
-
-> App URL: https://wasmer-wcgi-rust-template.wasmer.app # 👈🏼 This is the URL of our app
-> Versioned URL: https://rp9hwiqclq02.id.wasmer.app # 👈🏼 This is the versioned URL of our app
-> Admin dashboard: https://wasmer.io/apps/wasmer-wcgi-rust-template
+→ Unique URL: https://2j6h5i7cpmj6.id.wasmer.app
+→ Dashboard:  https://wasmer.io/apps/wasmer-user/hello-cgi
 
 Waiting for new deployment to become available...
 (You can safely stop waiting now with CTRL-C)
 .
-New version is now reachable at https://wasmer-wcgi-rust-template.wasmer.app
-Deployment complete
+𖥔 Deployment complete
 ```
+
+Note how there's been a new file, `app.yaml` created.
+This file configures how to deploy your app to Wasmer edge.
 
 ### Testing the deployed app
 
 We can test the deployed app using `curl`.
 
 ```bash copy
-curl https://wasmer-wcgi-rust-template.wasmer.app
+curl https://hello-cgi-wasmer-user.wasmer.app
 ```
+
+<Callout type="info" emoji="ℹ">
+    The deployment URL follows the format `https://<app-name>-<app-owner>.wasmer.com`
+</Callout>
 
 ```console
 Hello, World!

--- a/pages/edge/learn/apps.mdx
+++ b/pages/edge/learn/apps.mdx
@@ -17,13 +17,12 @@ be started to serve requests, and shut down again after a short idle period.
 Apps are reachable through an automatically provisioned URL (`NAME.wasmer.app`), 
 
 <Callout type='info'>
-Note: in the future apps will also be able to be persistent and stateful with persistent volumes.
-Apps will also expand to provide generic TCP/UDP servers, not just HTTP.
+In the future, apps will expand to provide generic TCP/UDP servers, not just HTTP.
 </Callout>
 
 ## Deployment Flow
 
-Apps are based on a [configuration file](../configuration/app-configuration), which
+Apps are based on a [configuration file](/edge/configuration), which
 can also be managed through the admin UI.
 
 Each deployment of an app will create a new app version. Each version will also

--- a/pages/edge/learn/connecting-domains-to-edge.mdx
+++ b/pages/edge/learn/connecting-domains-to-edge.mdx
@@ -22,25 +22,17 @@ And it should be done! You can now access your app on `blogs.wasmer.io`.
 
 Connecting a root domain is a bit more complicated than connecting a subdomain, because you can't create a CNAME record for a root domain.
 Some large DNS providers emulate root CNAME records. If your provider doesn't allow you to do that, you can use a service like [Cloudflare](https://www.cloudflare.com/).
-Note: this requires moving your entire DNS setup to Clouflare.
+Note: this requires moving your entire DNS setup to Cloudflare.
 
 <Callout type="default" emoji="⚠️">
-  If your domain is not controlled by Cloudflare you can transfer it by
-  following the guide{" "}
-  <a href="https://developers.cloudflare.com/registrar/get-started/transfer-domain-to-cloudflare/">
-    here
-  </a>
+  If your domain is not controlled by Cloudflare you can transfer it by following the guide [here](https://developers.cloudflare.com/registrar/get-started/transfer-domain-to-cloudflare/)
 </Callout>
 
 <Callout type="info" emoji="ℹ️">
-  Cloudflare does this by **CNAME flattening**. You can read more about it{" "}
-  <a href="https://blog.cloudflare.com/introducing-cname-flattening-rfc-compliant-cnames-at-a-domains-root/">
-    here
-  </a>
+  Cloudflare does this by **CNAME flattening**. You can read more about it [here](https://blog.cloudflare.com/introducing-cname-flattening-rfc-compliant-cnames-at-a-domains-root/)
 </Callout>
 
-If you want to connect your root domain (e.g. `wasmer.io`), to your app hosted on Wasmer Edge
-You will need to create two additional records:
+If you want to connect your root domain (e.g. `wasmer.io`), to your app hosted on Wasmer Edge you will need to create two additional records:
 
     1. A CNAME record pointing to your app on wasmer edge.
     2. A TXT record with the value `cname: wasmer.sh.       cname:wasmer--wasmer-sh.wasmer.app."

--- a/pages/edge/learn/deployment-modes.mdx
+++ b/pages/edge/learn/deployment-modes.mdx
@@ -11,7 +11,7 @@ There are different ways to deploy applications on Wasmer Edge:
 
 <Callout>
 
-TCP and UDP applications are also supported in Wasmer Edge, but we haven't exposed the API as is still in alpha phase.
+Although TCP and UDP applications are supported in Wasmer Edge, we haven't yet exposed the API as it's still in alpha phase.
 
 If you want to run TCP or UDP applications (such as video server, a websockets application or more)
 please [let us know on this issue](https://github.com/wasmerio/wasmer-edge-support/issues/1), or ping us in [Wasmer Discord](https://discord.gg/qBTfsNP7N8).

--- a/pages/edge/learn/instaboot.mdx
+++ b/pages/edge/learn/instaboot.mdx
@@ -19,7 +19,7 @@ InstaBoot allows fast startup by creating a snapshot of your app that is fully
 initialized and ready to serve requests.
 
 Snapshots are created by starting a new application instance and warming it up
-with a series of warm-up requests to the application.
+with a series of warm-up requests.
 These warm-up requests have to be specified in your app configuration.
 
 Once a snapshot is created, Edge can use the snapshot to start apps almost instantly!
@@ -98,9 +98,12 @@ response header.
 
 If your app was started from a snapshot, the header will read:
 
-* `X-Edge-Instance-Journal-Status: bootsrap=journal+memory`
+* `X-Edge-Instance-Journal-Status: bootstrap=journal+memory`
 
-*Just remember to disable debug mode again before going to production!*
+
+<Callout type='warning'>
+Remember to disable debug mode before going to production!
+</Callout>
 
 ## Limiting the Snapshot Lifetime
 

--- a/pages/edge/learn/remote-sessions.mdx
+++ b/pages/edge/learn/remote-sessions.mdx
@@ -26,8 +26,8 @@ To start a session:
 
 Once that is done, you can simply run:
 
-```bash
-$ wasmer ssh
+```bash copy
+wasmer ssh
 ```
 
 This will drop you right into a interactive bash session.
@@ -38,13 +38,13 @@ packages from the Wasmer registry inside your ssh session.
 
 For example:
 
-```bash
-$ wasmer run john-sharratt/catsay meow
+```bash copy
+wasmer run john-sharratt/catsay meow
 ```
 
 To forward a port, run:
 
-```bash
+```bash copy
 wasmer ssh --map-port 9000
 ```
 
@@ -60,8 +60,8 @@ The below will first start a session with port 9000 mapped.
 We then create a `public` directory and a stub `index.html` file, and start a
 static web server on port 9000.
 
-```bash
-$ wasmer ssh --map-port 9000
+```bash copy
+wasmer ssh --map-port 9000
 
 > mkdir public
 > echo HELLO > public/index.html

--- a/pages/edge/learn/secrets.mdx
+++ b/pages/edge/learn/secrets.mdx
@@ -12,8 +12,6 @@ dashboard of your app on the [wasmer.io](https://wasmer.io) website.
 
 We designed both these mechanisms to be secure, intuitive and accomodating.
 
-#### Creating secrets
-
 ##### From the app dashboard 
 Once reached the dashboard of the app you want to add secrets to, simply click
 on _Settings_ and then select the _Secrets_ tab. From that page, you can see
@@ -30,6 +28,9 @@ button.
   className="bg-[#111111] rounded-lg p-4 dark:bg-transparent"
 />
 
+### Creating secrets
+There is two ways to create secrets:
+
 ##### From the CLI
 The `wasmer app secrets create` command allows you to create a new secret for
 your app. The command is able to automatically infer which app you want to tie
@@ -39,8 +40,12 @@ flags to specify the app to tie secrets to directly from the command line.
 
 You can specify the name and value of the secret directly as arguments of the
 CLI command: 
-```sh
-$ wasmer app secrets create MY_NEW_SECRET "its value"
+```bash copy
+wasmer app secrets create MY_NEW_SECRET "its value"
+```
+
+Expect something like:
+```
 Succesfully created secret(s):
 MY_NEW_SECRET
 ```
@@ -48,7 +53,7 @@ MY_NEW_SECRET
 If you want to create multiple secrets in bulk, the subcommand offers the 
 `--from-file` flag that allows you to specify a `.env`-like file from which 
 secrets are read off: 
-```sh 
+```bash
 $ cat .env
 QUOTH_THE_RAVEN="NEVERMORE"
 AGAIN_QUOTH_THE_RAVEN="NEVERMORE"
@@ -60,6 +65,7 @@ AGAIN_QUOTH_THE_RAVEN
 ```
 
 #### Listing secrets
+There is two ways of listing secrets:
 
 ##### From the app dashboard 
 Once reached the dashboard of the app you want to list secrets of, simply
@@ -83,8 +89,8 @@ simply executing the command in a directory with an `app.yaml` configuration
 file. The CLI also has the `--app` and `--app-dir` flags to specify the app to
 tie secrets to directly from the command line. 
 
-```sh
-$ wasmer app secrets list        
+```bash
+$wasmer app secrets list        
  Name                   Last updated      
  MY_NEW_SECRET          11m 59s ago 
  QUOTH_THE_RAVEN        3m 34s ago  
@@ -200,14 +206,14 @@ You can specify the name of the secret directly as arguments of the
 CLI command. In order to avoid users inadvertedly delete a secret, by default 
 the command asks the user for confirmation:
 ```sh
-$ wasmer app secrets delete QUOTH_THE_RAVEN 
+wasmer app secrets delete QUOTH_THE_RAVEN 
 ✔ Delete secret 'QUOTH_THE_RAVEN'? · yes
 Correctly deleted secret 'QUOTH_THE_RAVEN'
 ```
 
 To stop the CLI from asking you safety confirmations, just use the `--force` flag: 
 ```sh
-$ wasmer app secrets delete AGAIN_QUOTH_THE_RAVEN --force
+wasmer app secrets delete AGAIN_QUOTH_THE_RAVEN --force
 Correctly deleted secret 'AGAIN_QUOTH_THE_RAVEN'
 ```
 

--- a/pages/edge/learn/volumes.mdx
+++ b/pages/edge/learn/volumes.mdx
@@ -8,8 +8,7 @@ They also support remote access with any S3 compatible client.
 
 
 <Callout type="warning">
-In the current initial implementation, volumes are restricted to a single
-[Edge region](/edge/learn/regions).
+In the current initial implementation, volumes are restricted to a single [Edge region](/edge/learn/regions).
 
 Volumes also at the moment only provide *read-write-many* semantics.
 Due to the automatic auto-scaling for apps, this means that volumes are not currently
@@ -77,7 +76,10 @@ You can inspect volumes in two ways:
 * in the web frontend on your app dashboard:
   Go to the "Storage" tab - you will see a list of volumes with their size.
 * using the CLI:
-  Run `wasmer app volumes list [app]` to list all volumes and their sizes.
+
+```bash copy
+wasmer app volumes list [app]
+```
 
 ## Remotely Accessing Volumes
 
@@ -86,7 +88,7 @@ through the standard S3 API, or through a builtin web UI.
 
 You can use the CLI to retrieve the credentials:
 
-```bash
+```bash copy
 wasmer app volumes credentials --format=json
 ```
 
@@ -104,7 +106,7 @@ to your volumes. It even allows mounting a volume to your local machine!
 
 You can get an rclone configuration snippet through the CLI:
 
-```bash
+```bash copy
 wasmer app volumes credentials --format=rclone
 ```
 
@@ -140,7 +142,7 @@ rclone mount <target>:<volume-name> ./my-volume
 In order to rotate (i.e. automatically assign a different value) the credentials tied to your volumes, 
 you can simply run this command with the CLI: 
 
-```bash
+```bash copy
 wasmer app volumes rotate-secrets 
 ```
 

--- a/pages/edge/observability/logging.mdx
+++ b/pages/edge/observability/logging.mdx
@@ -42,7 +42,7 @@ Some example commands, which assume that your application is called `webserver`:
 
 - Retrieve logs for the last ten minutes:
 
-```bash
+```bash copy
 wasmer app logs webserver
 ```
 
@@ -50,13 +50,13 @@ wasmer app logs webserver
 
 Note the `--max XXX` entry to limit the amount of retrieved log lines.
 
-```bash
+```bash copy
 wasmer app logs --max 1000 --from 2023-06-10 --until 2023-06-10T10:00:00
 ```
 
 - Retrieve logs in JSON format for further processing:
 
-```bash
+```bash copy
 wasmer app logs -f json
 ```
 

--- a/pages/sdk/wasmer-js/tutorials/package.mdx
+++ b/pages/sdk/wasmer-js/tutorials/package.mdx
@@ -23,7 +23,7 @@ We can use the `wasmer` CLI to create a new package. From the
 `markdown-renderer/` crate created in the previous tutorial, run the following:
 
 ```sh
-$ wasmer init
+wasmer init
 NOTE: Initializing wasmer.toml file with metadata from Cargo.toml
   -> ./Cargo.toml
 ```
@@ -79,7 +79,7 @@ registry.
 
 
 ```sh
-$ wasmer publish
+wasmer publish
 [1/2] ⬆️   Uploading...
 [2/2] 📦  Publishing...
 Successfully published package `wasmer-examples/markdown-renderer@0.1.0`
@@ -92,14 +92,14 @@ Wasmer registry.
 You can check your authentication status using the following command:
 
 ```sh
-$ wasmer whoami
+wasmer whoami
 logged into registry "https://registry.wasmer.io/graphql" as user "michael-f-bryan"
 ```
 
 Otherwise, you will need to log in.
 
 ```sh
-$ wasmer login
+wasmer login
 Opening auth link in your default browser: https://wasmer.io/auth/cli?nonce_id=...&secret=...
 Waiting for session... Done!
 ✅ Login for Wasmer user "michael-f-bryan" saved


### PR DESCRIPTION
A lot of cleanup on many pages. Consistent changes:

* Added 'copy' tag on most commands so they're copyable
* Removed ` $ ` in front of all copyable fields
* Attempted to unify the docs so that they appear to have been written
by the same person, or at least following the same structure
* Updated the example output of the wasmer CLI

---

Some guides, like the cdn, required almost complete rewrite since the template had been changed.

I'll post the issues and bugs I found along the way on slack + notion, some pages needs to be updated entirely,
but I think that's best covered in separate issues.
