### PR TITLE
docs: fix spelling and grammar

### DIFF
--- a/pages/edge.mdx
+++ b/pages/edge.mdx
@@ -4,9 +4,9 @@ import DeployIcon from '../components/icons/deploy.svg'
 
 # Wasmer Edge
 
-Wasmer Edge is a next-generation cloud platform powered by WebAssembly, Wasmer and WASIX.
+Wasmer Edge is a next-generation cloud platform powered by WebAssembly, Wasmer, and WASIX.
 
-You can move now your applications to the Edge and scale them like serverless at extremely affordable prices.
+You can now move your applications to the edge and scale them like serverless workloads at extremely affordable prices.
 
 ## 🐥 First Steps
 
@@ -25,8 +25,8 @@ To understand how the platform works, check out the [Architecture](/edge/archite
 Wasmer Edge has many features, and we have many more in development:
 
 - **Stateless** HTTP workloads: <br/>
-  You can use [proxy](/edge/learn/deployment-modes#proxy) or to run web servers in the edge. [WCGI](/edge/learn/deployment-modes.mdx#wcgi) mode to run CGI in the edge.
-  If you are interested about TCP/UDP, [please reach us so we can enable it for you](/edge/learn/deployment-modes#tcpudp-applications).
+  You can use [proxy](/edge/learn/deployment-modes#proxy) to run web servers at the edge or [WCGI](/edge/learn/deployment-modes.mdx#wcgi) to run CGI at the edge.
+  If you are interested in TCP/UDP, [please reach us so we can enable it for you](/edge/learn/deployment-modes#tcpudp-applications).
 - **Automatic scaling**: <br/>
   Workloads will be served by the Wasmer Edge network, on the servers closest
   to the user, and will scale automatically to meet the demand.
@@ -35,9 +35,9 @@ Wasmer Edge has many features, and we have many more in development:
   You can also configure additional aliases.
 - **Versioned deployments and rollback**:<br/>
   App deployment versions are tracked.
-  You can always access previous versions though a special URL, and rollback to
+  You can always access previous versions through a special URL, and roll back to
   previous versions with a single CLI command or click.
-  You can also publish preview-versions and test them before switching them to active.
+  You can also publish preview versions and test them before switching them to active.
 - **Custom domains with automatic SSL**: <br/>
   You can configure custom domains and subdomains for your applications.
   SSL certificates will automatically be provisioned and renewed for you.
@@ -49,19 +49,19 @@ Wasmer Edge has many features, and we have many more in development:
 - **Persistent workloads**: <br />
   Apps are stateless and auto-scaled by default, which is great for scalability
   and cost-effectiveness, but sometimes you need to run a persistent workload
-  that keep running, even with no requests coming in.<br />
+  that keeps running even with no requests coming in.<br />
   Persistent workloads will enable you to provision a fixed number of instances
   that are kept alive by the edge runtime.
 
 - **Persistent volumes**: <br />
   Stateless apps are great for scalability, but eventually the state needs to
   live somewhere.
-  You will be able to create persistent volumes, and mount these volumes into
+  You will be able to create persistent volumes and mount these volumes into
   your workloads.
 
 - **Private network**: <br />
   Create secure, private networks to connect your workloads globally.
-  Powered by [DNET](/edge/architecture#wasmer-distributed-networking-dnet);
+  Powered by [DNET](/edge/architecture#wasmer-distributed-networking-dnet).
 
 - **Scheduled tasks / cronjobs**: <br />
   Running tasks at a certain interval is a common requirement.

--- a/pages/edge/cli.mdx
+++ b/pages/edge/cli.mdx
@@ -6,7 +6,7 @@ The most important ones are `wasmer deploy` and the subcommands of `wasmer app`.
 
 <Callout type="info">
   **Note:** To deploy apps on Wasmer Edge an account is required. When
-  deploying an app, you will be prompted to login if you are not already. 
+  deploying an app, you will be prompted to log in if you are not already.
 </Callout>
 
 <Callout>
@@ -50,10 +50,10 @@ Options:
       ...
 ```
 
-The `wasmer deploy` command has many flags, but does not have any mandatory
-argument. Its objective is that of loading the user-provided data - thus,
-possibly, [publishing](/registry/cli) a package as well - in Wasmer Edge and
-providing the needed informations for the user to manage their application.
+The `wasmer deploy` command has many flags but does not have any mandatory
+argument. Its objective is to load the user-provided data—possibly
+[publishing](/registry/cli) a package as well—into Wasmer Edge and
+provide the information needed for the user to manage their application.
 
 Based on the kind of app the user wants to deploy, the `wasmer deploy`
 command carries out different actions. In a nutshell, from the CLI perspective,
@@ -69,11 +69,11 @@ the package's manifest.
 
 In the latter case, the `wasmer deploy` command recognizes that the user
 might want to edit some of the metadata about the package and, if needed,
-prompts the user to decide on that regard. One example is that of the package
+prompts the user to decide accordingly. One example is that of the package
 version: in interactive mode, if the `--bump` flag was not given, the user will
 be asked if a patch version bump is needed. This, however, is not the only way
 to specify the version of a package: for a deeper dive into this matter, check
-out the [`publish` page](/registry/cli). 
+out the [`publish` page](/registry/cli).
 
 Once these matters are decided upon, this deployment flow concludes just as the
 former: your app is available!
@@ -112,13 +112,13 @@ Waiting for new deployment to become available...
 Once an app is deployed, the `wasmer` CLI provides a number of tools to manage
 it. 
 
-### Gathering informations about apps (`wasmer app info` and `wasmer app get`)
-In order to fetch structured informations about your app, you can use the
-`wasmer app get`, that provides the user with a number of informations about
+### Gathering information about apps (`wasmer app info` and `wasmer app get`)
+In order to fetch structured information about your app, you can use
+`wasmer app get`, which provides the user with a number of information about
 the app structured as a YAML value, ranging from the identifier of the app to
-the raw value of the `app.yaml` config file used to create the app. 
+the raw value of the `app.yaml` config file used to create the app.
 
-The `wasmer app info` command provides a synthesis of these informations, in
+The `wasmer app info` command provides a synthesis of this information, in
 particular the app name, the owner of the app, and relevant URLs.
 
 ```
@@ -178,7 +178,7 @@ Options:
       --template <TEMPLATE>
           A reference to the template to use.
 
-          It can be either an URL to a github repository - like `https://github.com/wasmer-examples/php-wasmer-starter` -  or the name of a template that will be searched for in the selected registry, like `astro-starter`.
+          It can be either a URL to a GitHub repository – like `https://github.com/wasmer-examples/php-wasmer-starter` – or the name of a template that will be searched for in the selected registry, like `astro-starter`.
 
       --package <PACKAGE>
           Name of the package to use
@@ -211,8 +211,8 @@ wasmer app create
 {/* [TODO]: Add link to templates list */}
 
 Templates allow users to kickstart their custom application from one of the
-available boilerplates like a static website, a php application, a javascript
-worker and much more. Another possibility is that of creating an app from an
+available boilerplates like a static website, a PHP application, a JavaScript
+worker, and much more. Another possibility is that of creating an app from an
 existing package: for example, as a starting step, the user can create the app
 from an existing package, like
 [`wasmer/hello`](https://wasmer.io/wasmer/hello).
@@ -232,7 +232,7 @@ owner: <YOUR-NAME>
 package: wasmer/hello
 ```
 
-This file contains all the necessary informations required to deploy your app
+This file contains all the necessary information required to deploy your app
 to Wasmer Edge. To learn more about this configuration file, refer to the
 [dedicated _Learn_ page](/edge/learn/apps). After having everything in place -
 whether it is from templates or pre-existing packages - the command will ask

--- a/pages/edge/configuration.mdx
+++ b/pages/edge/configuration.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra-theme-docs";
 
 # App Configuration (`app.yaml`)
 
-Wasmer Edge's configuration is stored in a `app.yaml` file in the root of your project.
+Wasmer Edge's configuration is stored in an `app.yaml` file in the root of your project.
 
 ## Example
 
@@ -143,7 +143,7 @@ volumes:
   # A name for your volume.
   # Must be unique for the given app.
   - name: data
-    # Where to moint the volume into the filesystem.
+    # Where to mount the volume into the filesystem.
     mount: /data
 ```
 
@@ -162,7 +162,7 @@ Database credentials are provided as *environment variables*:
 
 Currently only `mysql` is supported.
 
-**Note**: databases are tied to regions. When speciyfing a database, you should
+**Note**: databases are tied to regions. When specifying a database, you should
 also specify your desired region with the `locality.regions` setting.
 Only some of the regions support databases!
 
@@ -201,12 +201,12 @@ capabilities:
     requests:
       - path: /
       - path: /_bootstrap
-        # You can optionally speciy a maximum age.
+        # You can optionally specify a maximum age.
         # If the maximum age is reached, a new snapshot will automatically
         # be created, and the old ones discarded
         max_age: 12h
 
-        # Optionally request settings:
+        # Optional request settings:
         method: POST
 	body: "custom body"
 	headers:
@@ -216,13 +216,13 @@ capabilities:
 
 ### `health_checks`
 
-The `health_checks` field is used to check if an application is working correctly. If the healthchecks fail, edge will restart the application. It is **optional** and its an array of healtcheck objects
+The `health_checks` field is used to check if an application is working correctly. If the health checks fail, edge will restart the application. It is **optional** and it is an array of health check objects
 
 - Required: `false`
 
-Currently only supported healthcheck type is `http`. It executes an http request against the application. All the supported 
+Currently the only supported health check type is `http`. It executes an HTTP request against the application. All the supported
 
-##### Example healthcheck
+##### Example health check
 
 ```yaml filename="app.yaml" copy
 health_checks:
@@ -239,27 +239,27 @@ health_checks:
       expected_body_includes: Hello World
       expected_body_regex: ".*Wasmer.*"
 ```
-Fields for http healthcheck:
+Fields for HTTP health check:
 - #### `method`: Required
-  HTTP method to use. 
+  HTTP method to use.
 - #### `path`: Required
-  Path to send request to. 
+  Path to send the request to.
 - #### `interval`: Required
-  Duration between each request
+  Duration between each request.
 - #### `timeout`: Required
-  Timeout duration for requests
+  Timeout duration for requests.
 - #### `unhealthy_threshold`: Required
-  After `unhealthy_threshold` amount of failure of the http requests, app is considered unhealthy and will be restarted
+  After `unhealthy_threshold` failed HTTP requests, the app is considered unhealthy and will be restarted.
 - #### `healthy_threshold`: Required
-  After `healthy_threshold` amount of failure of the http requests, app is considered healthy and will be restarted
+  After `healthy_threshold` successful HTTP requests, the app is considered healthy.
 - #### `expected_status_codes`: Required
-  If the application returns these status codes, then the request will be count as successful
+  If the application returns these status codes, the request counts as successful.
 - #### `expected_body_includes`:
-  If this is specified, response body should include the string defined in this field to be count as successful
+  If this is specified, the response body should include the string defined in this field to be counted as successful.
 - #### `expected_body_regex`:
-  If this is specified, response body should be able to match the regular expression defined in this field to be count as successful
+  If this is specified, the response body should match the regular expression defined in this field to be counted as successful.
 
-So in the example above, if the application fails two consequent request, application will be restarted. It will be keep restarted until it successfully responds to one request
+So in the example above, if the application fails two consecutive requests, the application will be restarted. It will keep restarting until it successfully responds to one request.
 
 ### `locality`
 
@@ -292,16 +292,16 @@ The `scaling` field is used to configure how your application scales on Edge.
 
 Scaling mode for the app.
 
-**NOTE**: You should usually stick to the default behaviour,
+**NOTE**: You should usually stick to the default behavior,
 which is enabled when no scaling mode is specified.
-Only use the below modes if you you are sure they are appropriate!
+Only use the modes below if you are sure they are appropriate!
 
 Available values:
 
 * `<unset>`
 
   If no scaling mode is specified, Edge will send multiple requests to each instance, and also scale up additional instances if required.
-  This is the default, and the recommended mode if your program can handle multiple requests concurrently (Rust, Go, ...).
+  This is the default and the recommended mode if your program can handle multiple requests concurrently (Rust, Go, ...).
 
 * `single_concurrency`
 
@@ -323,4 +323,4 @@ scaling:
 
 ### `jobs`
 
-This section is defined on [jobs](/edge/configuration/jobs) page.
+This section is defined on the [jobs](/edge/configuration/jobs) page.

--- a/pages/edge/get-started.mdx
+++ b/pages/edge/get-started.mdx
@@ -22,8 +22,8 @@ Welcome to `wasmer deploy`. For most languages and frameworks, you can deploy yo
 
 
 The `wasmer deploy` command will make sure that everything is in place for you to deploy your
-app: it will guide you through the creation of the app and its deployment if doesn't exist,
-or to redeploy after it changes.
+app: it will guide you through the creation of the app and its deployment if it doesn't exist,
+or redeploy it after it changes.
 
 </Steps>
 

--- a/pages/edge/guides/js-wintercg.mdx
+++ b/pages/edge/guides/js-wintercg.mdx
@@ -9,7 +9,7 @@ import CliVersionCallout from "@components/deploy/CliVersionCallout.mdx";
 
 In this guide, you'll learn the process of deploying a JS service
 worker on Wasmer Edge. We will cover installation of the CLI, setting up a new
-Javascript worker, and deploying it.
+JavaScript worker, and deploying it.
 
 ## Deploying a JS service worker
 
@@ -28,7 +28,7 @@ mkdir my-new-js-worker
 cd my-new-js-worker
 ```
 
-Then, running a single command, we can setup a js worker:
+Then, running a single command, we can set up a JS worker:
 
 ```bash copy
 wasmer deploy --template=js-worker
@@ -36,7 +36,7 @@ wasmer deploy --template=js-worker
 This will prompt you for the following:
 
 - **App owner**: This is the owner of the app.
-It can be your username or an organization; if you're logged in, the command will prompt you tochoose from your namespaces: by default, it will be your username.
+It can be your username or an organization; if you're logged in, the command will prompt you to choose from your namespaces: by default, it will be your username.
 - **App name**: This is the name of your app. By default, it will be the name of the current directory. 
 
 Expect to see output similar to this:
@@ -49,7 +49,7 @@ It seems you are trying to create a new app!
 Loading local package (manifest path: ~/wasmer-user/Projects/jsworker/.)
 ✔ Correctly built package locally
 ✔ Package correctly uploaded
-✔ Succesfully pushed release to namespace wasmer-user on the registry
+✔ Successfully pushed release to namespace wasmer-user on the registry
 Deploying app jsworker (wasmer-user) to Wasmer Edge...
 
 App jsworker (wasmer-user) was successfully deployed 🚀

--- a/pages/edge/learn/instaboot.mdx
+++ b/pages/edge/learn/instaboot.mdx
@@ -9,7 +9,7 @@ Wasmer Edge provides a special feature called `InstaBoot`, which can
 significantly reduce cold start times of Edge applications.
 
 <Callout type="info">
-Learn more about Instaboot and how it works in [Wasmer's official announcement](
+Learn more about InstaBoot and how it works in [Wasmer's official announcement](
 https://wasmer.io/posts/announcing-instaboot-instant-cold-starts-for-serverless-apps).
 </Callout>
 
@@ -185,7 +185,7 @@ Good use cases:
   Like PHP, Python will also have to load code at runtime and prepare it for
   execution. While the difference is not quite as stark as with PHP, the speedup
   can still be very significant.
-* WinterJS (Javascript):
+* WinterJS (JavaScript):
   While WinterJS startup times are generally fast, InstaBoot can still often
   cut cold start times in half.
 * Expensive cache warm-up

--- a/pages/edge/learn/remote-sessions.mdx
+++ b/pages/edge/learn/remote-sessions.mdx
@@ -14,7 +14,7 @@ This means you will be able to close the connection and then re-connect to your
 session later on, giving you a persistent remote environment.
 
 While this isn't available quite yet, sessions are already useful to explore the
-ecosystem and to test out the behaviour of your own apps.
+ecosystem and to test out the behavior of your own apps.
 
 ## Usage
 

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -24,14 +24,14 @@ Welcome to the Wasmer Documentation! 👋
 ## SDKs
 
 Wasmer is available in multiple programming languages and operating systems in the shape of SDKs.
-Using these SDKs, it's possible to embed wasmer modules compiled from other languages into your application.
+Using these SDKs, it's possible to embed Wasmer modules compiled from other languages into your application.
 We have set up the SDKs to allow using Wasmer easily anywhere:
 
-* [Wasmer JavaScript SDK](/sdk/wasmer-js): run your Wasmer packages in Javascript
+* [Wasmer JavaScript SDK](/sdk/wasmer-js): run your Wasmer packages in JavaScript
 
 ## Social
 
 For the latest articles on Wasmer features and developments, check out [our blog](https://wasmer.io/posts) or [follow us on X](https://x.com/wasmerio)!
-You can also chat with us using [Wasmer Discord channel](https://discord.com/invite/qBTfsNP7N8).
+You can also chat with us using the [Wasmer Discord channel](https://discord.com/invite/qBTfsNP7N8).
 
 Let's now dig deeper into how to install Wasmer, shall we? 🙂

--- a/pages/install.mdx
+++ b/pages/install.mdx
@@ -20,7 +20,7 @@ Wasmer allows you to run applications either **Standalone** (_via the CLI_) or *
     ```
 
     <Callout type="info">
-      Other installation methods available here:
+      Other installation methods are available here:
       https://github.com/wasmerio/wasmer-install
     </Callout>
 
@@ -49,7 +49,7 @@ Wasmer allows you to run applications either **Standalone** (_via the CLI_) or *
     ```
 
     <Callout type="info">
-      Other installation methods available here:
+      Other installation methods are available here:
       https://github.com/wasmerio/wasmer-install
     </Callout>
 

--- a/pages/registry.mdx
+++ b/pages/registry.mdx
@@ -4,7 +4,7 @@ import PublishIcon from '../components/icons/publish.svg'
 
 # Wasmer Registry
 
-The Wasmer Registry stores all Wasmer packages and allows exploring packages from other users and distribute your own ones.
+The Wasmer Registry stores all Wasmer packages and allows exploring packages from other users and distributing your own.
 
 You can explore packages published to the Wasmer Registry at [wasmer.io](https://wasmer.io/explore) or you can
 also [search for packages](https://wasmer.io/search?type=PACKAGE).
@@ -19,9 +19,9 @@ To publish your first package, check out the [Getting Started](/registry/get-sta
 
 ## Features
 
-All packages published to the Wasmer registry will automatically be available to run with the `wasmer` CLI tool, but not just that...
+All packages published to the Wasmer registry are automatically available to run with the `wasmer` CLI tool, and more:
 
-- **Executables**: The registry will automatically create executables for all platforms and chipsets, with no dependency of Wasmer
+- **Executables**: The registry will automatically create executables for all platforms and chipsets, with no dependency on Wasmer
 - **Automatic documentation**: If you annotate your package with bindings, the documentation and APIs will be automatically generated for all programming languages.
 
 

--- a/pages/registry/cli.mdx
+++ b/pages/registry/cli.mdx
@@ -22,10 +22,10 @@ Once you set up the values in your [`wasmer.toml` manifest](/registry/manifest),
 wasmer publish
 ```
 
-This command will create your Wasmer package, and publish it to the Wasmer registry.
+This command will create your Wasmer package and publish it to the Wasmer registry.
 
 <Callout type="info" emoji="ℹ️">
-  **Note:** You must login to wasmer to use the `publish` command.
+  **Note:** You must log in to Wasmer to use the `publish` command.
 </Callout>
 
 #### Dry run

--- a/pages/registry/discover.mdx
+++ b/pages/registry/discover.mdx
@@ -3,6 +3,6 @@
 All public packages published to Wasmer are searchable through the
 [Wasmer Search page](https://wasmer.io/search).
 
-Wasmer also has an explore page to help you digest the most popular packages:
+Wasmer also has an explore page to help you discover the most popular packages:
 
-https://wasmer.io/explore
+[Wasmer Explore](https://wasmer.io/explore)

--- a/pages/registry/get-started.mdx
+++ b/pages/registry/get-started.mdx
@@ -16,7 +16,7 @@ This page will guide you through installing Wasmer, and publishing a package to 
 
 ### Create a package
 
-To create your first Wasmer pacakge simply run `wasmer init`.
+To create your first Wasmer package simply run `wasmer init`.
 
 This should have created a `wasmer.toml` file with contents similar to:
 
@@ -63,7 +63,7 @@ Now, create your WebAssembly modules:
 
   </Tab>
   <Tab>
-    WASI is oficially supported by Rust, to compile to it you can simply do:
+    WASI is officially supported by Rust; to compile to it you can simply do:
 
     ```bash copy
     rustup target add wasm32-wasi
@@ -73,7 +73,7 @@ Now, create your WebAssembly modules:
   </Tab>
 </Tabs>
 
-Modify the `wasmer.toml` to point the module to the wasm file location `target/release/<your-module>.wasm`.
+Modify `wasmer.toml` to point the module to the wasm file location `target/release/<your-module>.wasm`.
 
 ### Publish your package
 

--- a/pages/registry/manifest.mdx
+++ b/pages/registry/manifest.mdx
@@ -2,7 +2,7 @@ import { Callout } from "nextra-theme-docs";
 
 # Wasmer Manifest (`wasmer.toml`)
 
-The manifest file called `wasmer.toml` is required [to publish](./get-started.mdx) to the [Wasmer registry](https://wasmer.io/products/registry); This file contains the package's dependencies, metadata, and commands are declared.
+The manifest file called `wasmer.toml` is required [to publish](./get-started.mdx) to the [Wasmer registry](https://wasmer.io/products/registry). This file contains the package's dependencies, metadata, and command declarations.
 
 <Callout type="default" emoji="💡">
   If you want to get assistance creating the `wasmer.toml` file you can simply
@@ -90,7 +90,7 @@ imports = ["http-client.wai", "logging.wai"]
 
 Note that the `module` may be either the name of a `[[module]]` in the current `wasmer.toml`, or it might come from a dependency. For example, `module = "python/python:python"` indicates the command uses the `python` module from the package's `python/python` dependency.
 
-It is valid (and often preferrable) for a `[command]` and `[module]` to have the same `name`.
+It is valid (and often preferable) for a `[command]` and `[module]` to have the same `name`.
 
 ```toml filename="wasmer.toml" copy
 # ...

--- a/pages/runtime.mdx
+++ b/pages/runtime.mdx
@@ -20,8 +20,8 @@ To run a package, check out the [Getting Started](/runtime/get-started/) guide.
 
 - **Secure** by default. No file, network, or environment access, unless explicitly enabled.
 - **Fast**. Run WebAssembly at near-native speeds.
-- **Pluggable**. Embeddable in multiple programming languages
-- Compliant with latest WebAssembly Proposals (SIMD, Reference Types, Threads, ...)
+- **Pluggable**. Embeddable in multiple programming languages.
+- Compliant with the latest WebAssembly proposals (SIMD, Reference Types, Threads, ...)
 
 ## Backends
 
@@ -36,8 +36,8 @@ The Wasmer Runtime supports multiple backends, depending on your needs:
 ### Integration backends:
 
 - **Browser**: it allows running Wasmer fully in the browser (via `wasm-bindgen`).
-- **JavascriptCore**: it allows running Wasmer using the WebAssembly engine inside JavascriptCore
-- **V8**: it allows running Wasmer using the WebAssembly engine inside V8 (can be run interpreter or with JIT)
+- **JavaScriptCore**: it allows running Wasmer using the WebAssembly engine inside JavaScriptCore
+- **V8**: it allows running Wasmer using the WebAssembly engine inside V8 (can run in interpreter mode or with JIT)
 - **WAMR**: it allows running Wasmer using the WAMR interpreter
-- **wasmi**: it allows running the wasmi interpreter
+- **wasmi**: it allows running Wasmer using the wasmi interpreter
 

--- a/pages/runtime/cli.mdx
+++ b/pages/runtime/cli.mdx
@@ -1,4 +1,5 @@
 # `wasmer run` CLI
+# `wasmer run` CLI
 
 Run a WebAssembly file or Wasmer container.
 
@@ -12,19 +13,19 @@ All packages published on [Wasmer Registry](/registry) can be run with the `wasm
 wasmer run python/python
 ```
 
-Some commands, such as `cowsay` have multiple commands that we can run (eg. `cowsay` or `cowthink`)
+Some packages, such as `cowsay`, have multiple commands that we can run (e.g., `cowsay` or `cowthink`)
 
 ```bash copy
 wasmer run syrusakbary/cowsay --command-name=cowthink Hello world
 ```
 
-If in your current dir you have a `wasmer.toml` file, you can simply run the local package with:
+If your current directory has a `wasmer.toml` file, you can simply run the local package with:
 
 ```bash copy
 wasmer run .
 ```
 
-Wasmer run also allows running from URLs (in case a package is hosted on a different registry).
+The `wasmer run` command also allows running from URLs (in case a package is hosted on a different registry).
 
 ```bash copy
 wasmer run https://wasmer.io/python/python
@@ -47,7 +48,7 @@ wasmer run my_program.wasm --singlepass
 
 ### Run a WASI or WASIX Module
 
-You can pass the arguments that will be given to the WASI program:
+You can pass arguments to the WASI program:
 
 ```bash copy
 wasmer run my_wasi_program.wasm -- arg1 arg2 arg3

--- a/pages/runtime/features.mdx
+++ b/pages/runtime/features.mdx
@@ -12,10 +12,10 @@ Wasmer supports many different backends, depending on your needs:
 * Other Runtimes:
   - _V8_: ideal for iOS, Android and development.
   - _Wasmi_: ideal for iOS, or any environment where only interpreters can run.
-  - _JavascriptCore_: ideal for macOS. See [announcement](https://wasmer.io/posts/wasmer-3_3-and-javascriptcore)
+  - _JavaScriptCore_: ideal for macOS. See [announcement](https://wasmer.io/posts/wasmer-3_3-and-javascriptcore)
   - _Browser_: to target the web
 
-Each of this backends support different features, and have different support for Operating Systems and Chipsets.
+Each of these backends supports different features and has varying support for operating systems and chipsets.
 
 ### WebAssembly Features
 
@@ -42,7 +42,7 @@ WebAssembly features:
 - ❌ Not yet supported (please ping us if you need this feature!)
 
 
-|                                       | Singlepass | Cranelift | LLVM | V8 | Wasmi | JavascriptCore | Browser |
+|                                       | Singlepass | Cranelift | LLVM | V8 | Wasmi | JavaScriptCore | Browser |
 | ------------------------------------- | ---------- | --------- | ---- | -- | ------| -------------- | ------- |
 | Bulk memory operations                | ✅         | ✅        | ✅   | ✅  | ✅     | ✅             | ✅      |
 | Multi-value return                    | 🔄         | ✅        | ✅   | ✅  | ✅     | ✅             | ✅      |
@@ -55,7 +55,7 @@ WebAssembly features:
 
 Wasmer features:
 
-| Features | Singlepass | Cranelift | LLVM | V8 | Wasmi | JavascriptCore | Browser |
+| Features | Singlepass | Cranelift | LLVM | V8 | Wasmi | JavaScriptCore | Browser |
 | -------- | ---------- | --------- | ---- | -- | ----- | -------------- | ------- |
 | Caching  | ✅         | ✅        | ✅   | ❌  | ❌     | ❌             | ❌      |
 | Metering | ✅         | ✅        | ✅   | ❌  | ❌     | ❌             | ❌      |
@@ -71,7 +71,7 @@ Wasmer features:
 | Singlepass     | ✅    | ✅    | ✅      | ❌   | ✅       | ❌      |
 | V8             | ✅    | ✅    | ✅      | ✅   | ✅       | ❌      |
 | Wasmi          | ✅    | ✅    | ✅      | ✅   | ✅       | ❌      |
-| JavascriptCore | ✅    | ✅    | ✅      | ❌   | ✅       | ❌      |
+| JavaScriptCore | ✅    | ✅    | ✅      | ❌   | ✅       | ❌      |
 | Browser        | ✅    | ✅    | ✅      | ✅   | ✅       | ✅      |
 
 ## Backend support by Chipset
@@ -83,5 +83,5 @@ Wasmer features:
 | Singlepass     | ✅     | ✅    | ❌  | ⏰            | ⏰            |
 | V8             | ✅     | ✅    | ✅  | ✅            | ✅            |
 | Wasmi          | ✅     | ✅    | ✅  | ✅            | ✅            |
-| JavascriptCore | ✅     | ✅    | ❌  | ❌            | ❌            |
+| JavaScriptCore | ✅     | ✅    | ❌  | ❌            | ❌            |
 | Browser        | ✅     | ✅    | ✅  | ✅            | ✅            |

--- a/pages/runtime/get-started.mdx
+++ b/pages/runtime/get-started.mdx
@@ -8,7 +8,7 @@ import Install from "../../components/install.mdx";
 
 This page will guide you through installing Wasmer, and running a package from the Wasmer Registry.
 
-The runtime can run any pacakge published to the Wasmer Registry.
+The runtime can run any package published to the Wasmer Registry.
 
 <Steps>
  

--- a/pages/runtime/runners/create.mdx
+++ b/pages/runtime/runners/create.mdx
@@ -1,13 +1,13 @@
 # How to create a Runner
 
-Runners allow anyone to create custom ways to run Wasmer packages / WebAssembly modules.
+Runners allow anyone to create custom ways to run Wasmer packages or WebAssembly modules.
 
 This can be incredibly useful for different use cases:
-* You are a game creator such as [WASM-4](https://wasm4.org/), or others, and you want to create a custom runner so your games can be published and run with Wasmer.
-* You have created a new [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) for using, for example, WebGPU in the server and the browser and you want to allow those programs to be published and run with Wasmer.
+* You are a game creator, such as [WASM-4](https://wasm4.org/), and you want to create a custom runner so your games can be published and run with Wasmer.
+* You have created a new [ABI](https://en.wikipedia.org/wiki/Application_binary_interface) for using, for example, WebGPU on the server and in the browser, and you want to allow those programs to be published and run with Wasmer.
 
 Other use cases?
 
-If you are interested in creating a custom runner, please let us know here!
+If you are interested in creating a custom runner, please let us know here:
 
 https://github.com/wasmerio/wasmer/discussions/3997

--- a/pages/runtime/runners/emscripten.mdx
+++ b/pages/runtime/runners/emscripten.mdx
@@ -10,7 +10,7 @@ Emscripten support is experimental in Wasmer
 
 ## Usage
 
-To use the emscripten runner, you need to specify the runner for you package in your `wasmer.toml` file:
+To use the Emscripten runner, you need to specify the runner for your package in your `wasmer.toml` file:
 
 ```toml  filename="wasmer.toml" copy
 # ...
@@ -23,4 +23,4 @@ runner = "https://webc.org/runner/emscripten"
 
 ## Learn More
 
-To learn more about emscripten runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.EMSCRIPTEN_RUNNER_URI.html).
+To learn more about the Emscripten runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.EMSCRIPTEN_RUNNER_URI.html).

--- a/pages/runtime/runners/wasix.mdx
+++ b/pages/runtime/runners/wasix.mdx
@@ -1,8 +1,8 @@
 # WASIX Runner
 
-WASIX is the long term stabilization and support of the existing [WASI ABI](https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md)
+WASIX is the long-term stabilization and support of the existing [WASI ABI](https://github.com/WebAssembly/WASI/blob/main/legacy/application-abi.md)
 plus additional non-invasive syscall extensions that complete the missing
-gaps sufficiently enough to enable real, practical and useful applications to be compiled and used.
+gaps sufficiently enough to enable real, practical, and useful applications to be compiled and used.
 
 WASIX was created by the Wasmer team to speed up the Wasmification of codebases around the world!
 
@@ -10,7 +10,7 @@ You can check more about WASIX on the [website](https://wasix.org/).
 
 ## Usage
 
-To use the WASIX runner, you need to specify the runner for you package in your `wasmer.toml` file:
+To use the WASIX runner, you need to specify the runner for your package in your `wasmer.toml` file:
 
 ```toml filename="wasmer.toml" copy
 # ...
@@ -23,4 +23,4 @@ runner = "https://webc.org/runner/wasi"
 
 ## Learn More
 
-To learn more about WASIX runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.WASI_RUNNER_URI.html).
+To learn more about the WASIX runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.WASI_RUNNER_URI.html).

--- a/pages/runtime/runners/wcgi.mdx
+++ b/pages/runtime/runners/wcgi.mdx
@@ -11,7 +11,7 @@ https://wasmer.io/posts/announcing-wcgi
 
 ## Usage
 
-To use the wcgi runner, you need to specify the runner for you package in your `wasmer.toml` file:
+To use the WCGI runner, you need to specify the runner for your package in your `wasmer.toml` file:
 
 ```toml filename="wasmer.toml" copy
 # ...
@@ -24,4 +24,4 @@ runner = "https://webc.org/runner/wcgi"
 
 ## Learn More
 
-To learn more about WCGI runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.WCGI_RUNNER_URI.html).
+To learn more about the WCGI runner, please click [here](https://docs.rs/webc/latest/webc/metadata/annotations/constant.WCGI_RUNNER_URI.html).

--- a/pages/wai.md
+++ b/pages/wai.md
@@ -1,7 +1,7 @@
 # WebAssembly Interfaces (WAI)
 
 The WebAssembly spec that was first released in 2017 was only a minimum viable
-product and deliberately left several features incomplete to be iterated on by
+product and deliberately left several features incomplete to be iterated upon by
 the ecosystem.
 
 Arguably the most important functionality gap is the fact that only WebAssembly
@@ -31,7 +31,7 @@ There are four main parts to WAI:
 - The host
 
 The [Wasmer Pack](../../) project provides a convenient way to consume
-WebAssembly packages which implement a WAI interface.
+WebAssembly packages that implement a WAI interface.
 
 Some useful links:
 
@@ -72,11 +72,11 @@ The WAI Bindgen code generator consumes `*.wai` files and generates glue code
 that [the host](#the-host) can use for using functionality from a WebAssembly
 module or [the guest](#the-guest) can use for implementing that functionality.
 
-There are two primary ways users will interact with WAI Bindgen, the
-`wai-bindgen` CLI, and the `wai-bindgen-*` family of crates.
+There are two primary ways users interact with WAI Bindgen: the
+`wai-bindgen` CLI and the `wai-bindgen-*` family of crates.
 
 The `wai-bindgen` CLI provides a command-line interface to the `wai-bindgen-*`
-crates, and is often used for once-off investigation or integration with a
+crates and is often used for one-off investigation or integration with a
 non-Rust build system.
 
 On the other hand, the `wai-bindgen-*` crates allow users to generate bindings

--- a/pages/wai/functions.md
+++ b/pages/wai/functions.md
@@ -16,7 +16,7 @@ Most guests will map functions to top-level functions, while most hosts will
 expose functions as some sort of callable object which eventually calls into
 the relevant part of the WebAssembly virtual machine.
 
-For a more details, consult [the *Item: `func`* section][func] in the `*.wai`
+For more details, consult [the *Item: `func`* section][func] in the `*.wai`
 format.
 
 [func]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-func

--- a/pages/wai/records.md
+++ b/pages/wai/records.md
@@ -1,10 +1,10 @@
 # Records
 
 A record is an abstract data type containing a series of named fields. It has no
-associated behaviour and acts as a way to group data together. In C++, this
+associated behavior and acts as a way to group data together. In C++, this
 would be referred to as a [plain old data][pod] type.
 
-Depending on the language, records may be expressed in in different ways.
+Depending on the language, records may be expressed in different ways.
 
 | Language   | Equivalent Construct     |
 | ---------- | ------------------------ |
@@ -25,7 +25,7 @@ record person {
 }
 ```
 
-For a more details, consult [the *Item: `record`* section][record] in the
+For more details, consult [the *Item: `record`* section][record] in the
 `*.wai` format.
 
 [dataclass]: https://peps.python.org/pep-0557/

--- a/pages/wai/resources.md
+++ b/pages/wai/resources.md
@@ -4,7 +4,7 @@ A resource represents an opaque object where the representation and underlying
 implementation is completely hidden from the outside world. Resources may have
 associated methods, static methods, or no methods at all.
 
-Depending on the language, records may be expressed in in different ways.
+Depending on the language, resources may be expressed in different ways.
 
 | Language   | Equivalent Construct         |
 | ---------- | ---------------------------- |
@@ -49,7 +49,7 @@ resource request {
 }
 ```
 
-For a more details, consult [the *Item: `resource`* section][resource] in the
+For more details, consult [the *Item: `resource`* section][resource] in the
 `*.wai` format.
 
 [resource]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-resource

--- a/pages/wai/types.md
+++ b/pages/wai/types.md
@@ -1,28 +1,28 @@
-# Builtin Types
+# Built-in Types
 
-All types that can be used in a `*.wai` file are intended to mappable to native
+All types that can be used in a `*.wai` file are intended to be mappable to native
 types in a general purpose programming language.
 
-The core basic types are
+The core basic types are:
 
 - Unsigned integers (`u8`, `u16`, `u32`, `u64`)
 - Signed integers (`s8`, `s16`, `s32`, `s64`)
 - Floating point numbers (`float32`, `float64`)
-- UTF-8 Strings (`string`)
+- UTF-8 strings (`string`)
 - UTF-8 code points (`char`)
 - [Void][void] or nothing (`unit`)
 
 For a more precise definition, consult [the *Types* section][types] in the
 `*.wai` format.
 
-## Other Builtin Types
+## Other Built-in Types
 
-Besides the basic builtin types, there are several "generic" types built into
-WAI which let users express common concepts.
+Besides the basic built-in types, there are several "generic" types built into
+WAI that let users express common concepts.
 
 ### Tuples
 
-The tuple is equivalent to a [record](./records.md) that has numeric fields.
+The tuple is equivalent to a [record](./records.md) with numeric fields.
 
 Code generators may be able to express tuples as a first-class concept. For
 example, `tuple<string, float32, float32>` would be expressed as
@@ -30,7 +30,7 @@ example, `tuple<string, float32, float32>` would be expressed as
 
 ### Lists
 
-Lists are dynamically-sized sequences of the same element type. Often called
+Lists are dynamically sized sequences of the same element type. Often called
 a "list", "vector", or "array", a `list<string>` would be expressed as
 `Vec<String>` in Rust.
 

--- a/pages/wai/variants.md
+++ b/pages/wai/variants.md
@@ -1,6 +1,6 @@
 # Enums, Flags, Variants, and Unions
 
-the concept of "this value can be X or Y or Z" can be expressed in several ways
+The concept of "this value can be X or Y or Z" can be expressed in several ways
 depending on the context.
 
 ## Enum
@@ -16,7 +16,7 @@ enum ordering {
 }
 ```
 
-For a more details, consult [the *Item: `enum`* section][enum] in the `*.wai`
+For more details, consult [the *Item: `enum`* section][enum] in the `*.wai`
 format.
 
 ## Flags
@@ -39,7 +39,7 @@ variants can be set at a time, whereas an `enum` can be only one thing at a
 time. Different languages are often able to express this in a very efficient
 form, typically an integer where each bit represents a different flag.
 
-For a more details, consult [the *Item: `flags`* section][flags] in the `*.wai`
+For more details, consult [the *Item: `flags`* section][flags] in the `*.wai`
 format.
 
 ## Variant
@@ -65,7 +65,7 @@ particular language.
 
 In Rust, a `variant` is just a normal `enum`.
 
-In TypeScript, the variant is implemented as a tagged union.
+In TypeScript, variants are implemented as tagged unions.
 
 ```ts
 type error = { type: "file-not-found", value: string }
@@ -73,7 +73,7 @@ type error = { type: "file-not-found", value: string }
     | { type: "other" };
 ```
 
-For a more details, consult [the *Item: `variant`* section][variant] in the
+For more details, consult [the *Item: `variant`* section][variant] in the
 `*.wai` format.
 
 ## Union
@@ -88,13 +88,13 @@ union configuration {
 ```
 
 This is distinct from a `variant` because some languages may be able to
-represent an `union` in a way that is more efficient or idiomatic.
+represent a `union` in a way that is more efficient or idiomatic.
 
-For a more details, consult [the *Item: `union`* section][union] in the
+For more details, consult [the *Item: `union`* section][union] in the
 `*.wai` format.
 
 
 [union]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-union-variant-but-with-no-case-names
-[enum]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-union-variant-but-with-no-case-names
+[enum]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-enum-set-of-named-values
 [variant]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-variant-one-of-a-set-of-types
 [flags]: https://github.com/wasmerio/wai/blob/main/WAI.md#item-flags-bag-of-bools

--- a/pages/wasmer-pack/how-to/resources-vs-records.md
+++ b/pages/wasmer-pack/how-to/resources-vs-records.md
@@ -4,7 +4,7 @@ The difference between a [resource](/wai/resources) and a
 [record](/wai/records) can be subtle when first starting out,
 but there is a simple rule of thumb that will work 90% of the time:
 
-> Records contain data, resources encapsulate behaviour.
+> Records contain data, resources encapsulate behavior.
 
 ## Typical Examples
 
@@ -58,9 +58,9 @@ When deciding between using a resource or a record, consider the following:
 
 ## Edge Cases
 
-While the *"Records contain data, resources encapsulate behaviour"* rule works
+While the *"Records contain data, resources encapsulate behavior"* rule works
 for most cases, you will almost certainly run into situations where something
-has both data and behaviour.
+has both data and behavior.
 
 This happens a lot when wrapping a "normal" library with a WAI interface so it
 can be used from WebAssembly. The distinction between "object" and "data" is
@@ -90,7 +90,7 @@ resource virtual-machine {
 
 This approach works particularly well when the methods will update state because
 all resources are reference types, meaning any modifications made to a resource
-through one handle (e.g. via a method) will be seen by all other handles to the
+through one handle (e.g., via a method) will be seen by all other handles to the
 same resource.
 
 One downside of this approach is that each getter or setter is implemented using
@@ -124,7 +124,7 @@ predicted-location: func(s: satellite, ts: timestamp) -> position
 ```
 
 This works well when the thing being expressed is mostly data, with only a
-couple of pieces of associated behaviour.
+couple of pieces of associated behavior.
 
 Records are passed around by value, meaning any operations that would normally
 modify a field will need to return a new value with the updated field, instead.

--- a/pages/wasmer-pack/tutorial/03-records.md
+++ b/pages/wasmer-pack/tutorial/03-records.md
@@ -162,22 +162,22 @@ impl geometry::Geometry for Geometry {
 > - `Geometry` is the struct
 > - `geometry::Geometry` is the Trait that implements the function `distance_between` on `Geometry`
 
-### Explaination
+### Explanation
 
-Here, the function `distance_between` takes two arguement of the _Point_ type. For simplicity we [destructure](https://doc.rust-lang.org/rust-by-example/flow_control/match/destructuring/destructure_structures.html) it for a clear distinction between the x1, x2 and y1,y2 as opposed to writing `p1.x` or `p1.y` everytime.
+Here, the function `distance_between` takes two argument of the _Point_ type. For simplicity we [destructure](https://doc.rust-lang.org/rust-by-example/flow_control/match/destructuring/destructure_structures.html) it for a clear distinction between x1, x2 and y1, y2 as opposed to writing `p1.x` or `p1.y` every time.
 
 We then find the distance between the two points using the [distance formula](https://en.wikipedia.org/wiki/Euclidean_distance).
 
 ##### Note📝
 
-> As `.wai` files only accept kebab-casing. The function `distance_between` in the `geometry.wai` will convert to the default casings for the respected language.
+> As `.wai` files only accept kebab-casing. The function `distance_between` in `geometry.wai` will convert to the default casings for the respective language.
 >
 > //change here after formatting!!
-> i.e: _snake_case_ for rust, _CamelCase_ for Javascript,
+> i.e., _snake_case_ for Rust, _CamelCase_ for JavaScript,
 
 ### Nested Records
 
-As we saw, the use of simpler identifiers to create a `Point` record. we can further extend this functionality using records or other valid `WAI types` to specify the record arguments to create more complex and _nested records_.
+As we saw, the use of simpler identifiers to create a `Point` record. We can further extend this functionality using records or other valid `WAI types` to specify the record arguments to create more complex and _nested records_.
 
 > ⚠️ Recursive types are explicitly forbidden in WAI.
 
@@ -189,7 +189,7 @@ record tree-node {
 
 > 👆🏼, is not allowed.
 
-Let's futher explain `Nested Records` this with an example:
+Let's further explain `Nested Records` with an example:
 
 > WAI file with nested records :
 

--- a/pages/wasmer-pack/tutorial/05-resources.md
+++ b/pages/wasmer-pack/tutorial/05-resources.md
@@ -2,10 +2,10 @@
 
 So far we've covered basic functions, numbers, strings, lists, records, and
 variants, but there's one key aspect in programming we haven't touched on yet -
-objects with behaviour and internal state!
+objects with behavior and internal state!
 
 In WIT, we use a `resource` to give the host access to an "object" that has
-behaviour without exposing how that object is implemented (or even which
+behavior without exposing how that object is implemented (or even which
 language it is implemented in).
 
 To explore this concept, we'll create a basic `Calculator` resource which lets
@@ -109,7 +109,7 @@ immutable `&self`. This means we'll need to use [interior mutability][int-mut]
 if we want to update internal state.
 
 While this might feel a bit awkward, there is a very good reason for requiring
-all state in a resource to synchronise its mutations - WebAssembly makes no
+all state in a resource to synchronize its mutations - WebAssembly makes no
 guarantees that the caller will respect the borrow checker.
 
 ## Publishing
@@ -175,7 +175,7 @@ $ python main.py
 
 ## Conclusion
 
-The resource is a useful tool for exposing stateful objects that have behaviour,
+The resource is a useful tool for exposing stateful objects that have behavior,
 and should be familiar to
 
 With the addition of resources, we've introduced most of the fundamental


### PR DESCRIPTION
## Summary
- fix spelling and grammar across documentation
- clarify configuration and runtime instructions

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68c00c7a87a4832e8b112a3c34ef173b