### PR TITLE
docs: Fix spacing in instaboot.mdx

### DIFF
--- a/pages/edge/learn/instaboot.mdx
+++ b/pages/edge/learn/instaboot.mdx
@@ -55,10 +55,10 @@ capabilities:
       - path: /_bootstrap
         # Optionally specify the request method, headers and body.
         method: POST
-	body: "{\"warm-up\": true}"
-	headers:
-	  - name: X-My-Header
-	    value: my-value
+        body: "{\"warm-up\": true}"
+        headers:
+          - name: X-My-Header
+            value: my-value
 ```
 
 That's it!


### PR DESCRIPTION
I guess `body` and `headers` should be under `method`

Currently at https://docs.wasmer.io/edge/learn/instaboot they are rendered wrong 
<img width="632" height="277" alt="image" src="https://github.com/user-attachments/assets/26d00646-3ff0-4425-9ae5-76d8e449dde4" />
