### PR TITLE
docs: Fix Github example link for js-worker

### DIFF
--- a/pages/edge/guides/js-wintercg.mdx
+++ b/pages/edge/guides/js-wintercg.mdx
@@ -204,5 +204,5 @@ Compare this to some of [the alternatives](/edge/vs/amazon-lambda).
 <Card
   icon={<GitHubLogo />}
   title="wasmer-examples/edge-js-service-worker"
-  href="https://github.com/wasmer-examples/js-service-worker-example"
+  href="https://github.com/wasmer-examples/js-worker-wasmer-starter"
 />


### PR DESCRIPTION
Current link is broken, I guess I've found a correct one