### PR TITLE
docs: Remove broken link to moved custom domains

### DIFF
--- a/pages/edge/configuration/_meta.json
+++ b/pages/edge/configuration/_meta.json
@@ -1,3 +1,0 @@
-{
-  "custom-domains": "Custom Domains (DNS)"
-}


### PR DESCRIPTION
Custom domains link is broken under Edge/Configuration
<img width="278" height="484" alt="image" src="https://github.com/user-attachments/assets/f7e9f007-04bb-47b6-b38e-db56b20b152a" />

Actual page was moved in https://github.com/wasmerio/docs.wasmer.io/commit/be248f594842ae4effdfb32677c28382746a4af9 but I guess `_meta.json` was simply forgotten, so menu still references a non-existing page.