### PR TITLE
Make JS install commands visually consistent

### DIFF
--- a/content/install.mdx
+++ b/content/install.mdx
@@ -67,7 +67,7 @@ Wasmer allows you to run applications either **Standalone** (_via the CLI_) or *
   <Tab>
     **NPM**:
 
-    ```bash copy
+    ```bash /@wasmer/ /sdk/ copy
     npm install @wasmer/sdk --save
     ```
 


### PR DESCRIPTION
<img width="312" height="254" alt="image" src="https://github.com/user-attachments/assets/b3e872e4-a67d-4a56-bc92-27906d743c30" />

In bun, the names are highlighted, in NPM they aren't. This isn't a big issue but just looks a bit odd.