### PR TITLE
docs: document Edge CDN Cache

### DIFF
--- a/content/edge/configuration.mdx
+++ b/content/edge/configuration.mdx
@@ -246,9 +246,9 @@ capabilities:
 - Required: `false`
 - Default: disabled
 
-`enabled` is currently the only supported CDN Cache setting. See the dedicated
-[CDN Cache documentation](/edge/learn/cdn-cache) for cache header
-semantics, dashboard configuration, and purge options.
+`enabled` is currently the only supported CDN Cache setting. See the
+[CDN Cache documentation](/edge/learn/cdn-cache) for cache header semantics,
+dashboard configuration, and purge options.
 
 #### `ssh`
 

--- a/content/edge/configuration.mdx
+++ b/content/edge/configuration.mdx
@@ -38,6 +38,10 @@ capabilities:
     requests:
       - path: /
       - path: /_bootstrap
+
+  # Cache eligible HTTP responses at the edge
+  cdn_cache:
+    enabled: true
 ```
 
 ## Fields
@@ -227,6 +231,24 @@ capabilities:
 	- name: X-My-Header
 	  value: my-value
 ```
+
+#### `cdn_cache`
+
+Enable CDN Cache for the app. CDN Cache stores eligible HTTP responses at the
+edge and reuses them for matching requests before they reach your app.
+
+```yaml filename="app.yaml" copy
+capabilities:
+  cdn_cache:
+    enabled: true
+```
+
+- Required: `false`
+- Default: disabled
+
+`enabled` is currently the only supported CDN Cache setting. See the dedicated
+[CDN Cache documentation](/edge/learn/cdn-cache) for cache header
+semantics, dashboard configuration, and purge options.
 
 #### `ssh`
 

--- a/content/edge/configuration/_meta.js
+++ b/content/edge/configuration/_meta.js
@@ -1,1 +1,3 @@
-export default {}
+export default {
+  "jobs": "Jobs"
+}

--- a/content/edge/learn/_meta.js
+++ b/content/edge/learn/_meta.js
@@ -1,5 +1,6 @@
 export default {
   "apps": "Apps",
+  "cdn-cache": "CDN Cache",
   "instaboot": "InstaBoot",
   "deployment-modes": "Deployment Modes",
   "supported-frameworks-and-languages": "Supported Frameworks and Languages",

--- a/content/edge/learn/cdn-cache.mdx
+++ b/content/edge/learn/cdn-cache.mdx
@@ -1,0 +1,195 @@
+import { Callout } from '@components/nextra-theme';
+
+# CDN Cache
+
+Wasmer Edge can cache HTTP responses at the edge before requests reach your app.
+This is useful for static assets, generated files, public API responses, and other
+content that can be reused safely across visitors.
+
+<Callout type="warning">
+  CDN Cache is currently in beta. The only app configuration setting available
+  today is `capabilities.cdn_cache.enabled`. Path-based caching rules will be
+  added later.
+</Callout>
+
+## How it works
+
+When CDN Cache is enabled, Wasmer Edge checks each incoming request before
+forwarding it to your app:
+
+1. If a fresh cached response exists, Edge returns it directly.
+2. If no usable cached response exists, Edge forwards the request to your app.
+3. If your app's response is cacheable, Edge stores it for future matching
+   requests.
+
+The cache is scoped to the app version that served the response. Deploying a new
+app version starts using a new cache namespace, so responses from the previous
+version are not reused for the new version.
+
+CDN Cache follows standard HTTP caching headers. Your app decides what can be
+cached by returning headers such as `Cache-Control`, `Expires`, `ETag`,
+`Last-Modified`, and `Vary`.
+
+## Enable CDN Cache
+
+Add `capabilities.cdn_cache.enabled: true` to your `app.yaml`, then deploy the
+app again.
+
+```yaml filename="app.yaml" copy
+kind: wasmer.io/App.v0
+owner: my-account
+name: my-app
+package: my-account/my-app
+
+capabilities:
+  cdn_cache:
+    enabled: true
+```
+
+`enabled` is the only CDN Cache setting supported in `app.yaml` today. If
+`capabilities.cdn_cache.enabled` is omitted or set to `false`, CDN Cache is not
+enabled for the app.
+
+You can also enable it from the Wasmer dashboard:
+
+1. Open your app in the Wasmer dashboard.
+2. Go to **App Settings**.
+3. Open the **CDN Cache** section.
+4. Enable CDN Cache.
+
+## Purge cached responses
+
+You can stop using old cached CDN responses or purge them in three ways:
+
+- Deploy a new app version with `wasmer deploy`. Because cache entries are
+  scoped by app version, the new version will not reuse cached responses from
+  the previous version.
+- Click the purge button in the dashboard's **App Settings** > **CDN Cache**
+  section.
+- Run the CLI purge command:
+
+```bash copy
+wasmer app cdn purge
+```
+
+Run the command from a directory containing the app's `app.yaml`, or pass the
+app identifier supported by the `wasmer app` commands.
+
+## What requests can be cached
+
+Only `GET` and `HEAD` requests are eligible for CDN Cache. Other HTTP methods
+bypass the cache and go directly to your app.
+
+Requests also bypass CDN Cache when they include any of these headers or
+directives:
+
+- `Authorization`
+- `Cookie`
+- `Pragma: no-cache`
+- `Cache-Control: no-store`
+- `Cache-Control: no-cache`
+- `Cache-Control: max-age=0`
+
+This means authenticated or personalized requests are not stored in the shared
+CDN cache.
+
+## What responses can be cached
+
+A response must have explicit caching headers to be stored. Responses without
+`Cache-Control` or `Expires` are not cached by default.
+
+A response is not stored when it:
+
+- includes `Set-Cookie`
+- includes `Vary: *`
+- has a `5xx` status code
+- does not include `Content-Length`
+- is larger than the platform's maximum CDN object size
+
+Unknown-length streamed responses are not cached. If you want a response to be
+eligible, include a correct `Content-Length` header.
+
+## Cache-Control semantics
+
+Use `Cache-Control` to tell Wasmer Edge whether a response can be stored and how
+long it stays fresh.
+
+```http
+Cache-Control: public, max-age=3600
+```
+
+The response above can be cached for one hour.
+
+Common directives:
+
+- `public`: allows the response to be stored by the shared CDN cache.
+- `max-age=<seconds>`: sets how long the response is fresh.
+- `s-maxage=<seconds>`: sets the shared-cache freshness lifetime and takes
+  precedence over `max-age`.
+- `no-store`: prevents CDN Cache from storing the response.
+- `private`: prevents the shared CDN cache from storing the response.
+- `no-cache`: allows storage, but requires revalidation before reuse.
+- `must-revalidate` and `proxy-revalidate`: require revalidation and prevent
+  serving stale cached responses.
+
+If `Cache-Control` is not present, `Expires` can make a response cacheable. When
+both headers are present, `Cache-Control` takes precedence.
+
+## Revalidation
+
+Wasmer Edge supports standard HTTP revalidation for stale cached responses.
+
+If the cached response includes `ETag`, Edge can revalidate with
+`If-None-Match`. If it includes `Last-Modified`, Edge can revalidate with
+`If-Modified-Since`. When your app returns `304 Not Modified`, Edge keeps the
+cached body and updates cache metadata from the revalidation response.
+
+For example:
+
+```http
+Cache-Control: public, max-age=60
+ETag: "asset-v1"
+```
+
+After 60 seconds, Edge can ask your app whether the cached response is still
+valid instead of downloading the full body again.
+
+## Vary
+
+`Vary` is honored when matching cached responses. For example, a response with
+`Vary: Accept-Language` is cached separately for different `Accept-Language`
+request header values.
+
+```http
+Cache-Control: public, max-age=3600
+Vary: Accept-Encoding
+```
+
+`Vary: *` prevents caching. When a response has a non-identity
+`Content-Encoding`, Edge also keys the cache by `Accept-Encoding` even if the
+origin response forgot to include `Vary: Accept-Encoding`.
+
+## Stale responses
+
+Wasmer Edge can briefly serve stale responses during revalidation or upstream
+errors when the response is allowed to be served stale.
+
+By default, Edge uses short stale windows to smooth traffic spikes and improve
+availability during temporary upstream errors. You can control this with
+standard response directives:
+
+```http
+Cache-Control: public, max-age=300, stale-while-revalidate=30, stale-if-error=600
+```
+
+Edge will not serve stale responses when the request includes
+`Cache-Control: no-cache`, or when the cached response requires revalidation
+with directives such as `no-cache`, `must-revalidate`, or `proxy-revalidate`.
+
+## Current limitations
+
+- CDN Cache is beta.
+- `capabilities.cdn_cache.enabled` is the only app-level configuration setting.
+- Path-based caching rules are not available yet. For now, enablement applies to
+  the app, and each response controls caching through HTTP headers.
+- Dashboard and CLI purges currently purge the app's CDN cache as a whole.

--- a/content/edge/learn/cdn-cache.mdx
+++ b/content/edge/learn/cdn-cache.mdx
@@ -2,38 +2,37 @@ import { Callout } from '@components/nextra-theme';
 
 # CDN Cache
 
-Wasmer Edge can cache HTTP responses at the edge before requests reach your app.
-This is useful for static assets, generated files, public API responses, and other
-content that can be reused safely across visitors.
+Wasmer Edge can cache HTTP responses at the edge and reuse them for matching
+requests before they reach your app. This speeds up delivery of static assets,
+generated files, public API responses, and any other content that is safe to
+share across visitors.
 
 <Callout type="warning">
-  CDN Cache is currently in beta. The only app configuration setting available
-  today is `capabilities.cdn_cache.enabled`. Path-based caching rules will be
-  added later.
+  CDN Cache is in beta. Enablement applies to the whole app, and each response
+  controls its own caching through standard HTTP headers. Path-based caching
+  rules will be added later. See [Limitations](#limitations) for the full list.
 </Callout>
 
 ## How it works
 
-When CDN Cache is enabled, Wasmer Edge checks each incoming request before
-forwarding it to your app:
+When CDN Cache is enabled, Edge checks each incoming request before forwarding
+it to your app:
 
 1. If a fresh cached response exists, Edge returns it directly.
-2. If no usable cached response exists, Edge forwards the request to your app.
-3. If your app's response is cacheable, Edge stores it for future matching
+2. Otherwise, Edge forwards the request to your app.
+3. If the app's response is cacheable, Edge stores it for future matching
    requests.
 
-The cache is scoped to the app version that served the response. Deploying a new
-app version starts using a new cache namespace, so responses from the previous
-version are not reused for the new version.
+Your app stays in control: it decides what can be cached by returning standard
+headers such as `Cache-Control`, `Expires`, `ETag`, `Last-Modified`, and `Vary`.
 
-CDN Cache follows standard HTTP caching headers. Your app decides what can be
-cached by returning headers such as `Cache-Control`, `Expires`, `ETag`,
-`Last-Modified`, and `Vary`.
+The cache is scoped to the app version that served the response. Each deploy
+starts a new cache namespace, so a new version never reuses the previous
+version's cached responses.
 
 ## Enable CDN Cache
 
-Add `capabilities.cdn_cache.enabled: true` to your `app.yaml`, then deploy the
-app again.
+Add `capabilities.cdn_cache.enabled: true` to your `app.yaml` and deploy:
 
 ```yaml filename="app.yaml" copy
 kind: wasmer.io/App.v0
@@ -46,42 +45,36 @@ capabilities:
     enabled: true
 ```
 
-`enabled` is the only CDN Cache setting supported in `app.yaml` today. If
-`capabilities.cdn_cache.enabled` is omitted or set to `false`, CDN Cache is not
-enabled for the app.
+When `enabled` is omitted or set to `false`, CDN Cache is off.
 
-You can also enable it from the Wasmer dashboard:
-
-1. Open your app in the Wasmer dashboard.
-2. Go to **App Settings**.
-3. Open the **CDN Cache** section.
-4. Enable CDN Cache.
+You can also toggle it from the dashboard: open your app, go to **App Settings**,
+and open the **CDN Cache** section.
 
 ## Purge cached responses
 
-You can stop using old cached CDN responses or purge them in three ways:
+Because cache entries are scoped to an app version, deploying a new version with
+`wasmer deploy` automatically stops reuse of the old version's cache.
 
-- Deploy a new app version with `wasmer deploy`. Because cache entries are
-  scoped by app version, the new version will not reuse cached responses from
-  the previous version.
-- Click the purge button in the dashboard's **App Settings** > **CDN Cache**
-  section.
-- Run the CLI purge command:
+To purge the current version's cache explicitly, use either:
 
-```bash copy
-wasmer app cdn purge
-```
+- The purge button in the dashboard, under **App Settings** > **CDN Cache**.
+- The CLI:
 
-Run the command from a directory containing the app's `app.yaml`, or pass the
-app identifier supported by the `wasmer app` commands.
+  ```bash copy
+  wasmer app cdn purge
+  ```
 
-## What requests can be cached
+  Run it from a directory containing the app's `app.yaml`, or pass an app
+  identifier as accepted by the other `wasmer app` commands.
 
-Only `GET` and `HEAD` requests are eligible for CDN Cache. Other HTTP methods
-bypass the cache and go directly to your app.
+## What gets cached
 
-Requests also bypass CDN Cache when they include any of these headers or
-directives:
+Only `GET` and `HEAD` requests are eligible. All other methods bypass the cache
+and go straight to your app.
+
+A request also bypasses the cache when it carries any of these headers or
+directives, so authenticated and personalized requests are never stored in the
+shared cache:
 
 - `Authorization`
 - `Cookie`
@@ -90,61 +83,47 @@ directives:
 - `Cache-Control: no-cache`
 - `Cache-Control: max-age=0`
 
-This means authenticated or personalized requests are not stored in the shared
-CDN cache.
-
-## What responses can be cached
-
-A response must have explicit caching headers to be stored. Responses without
-`Cache-Control` or `Expires` are not cached by default.
-
-A response is not stored when it:
+On the response side, caching is opt-in: a response must carry explicit caching
+headers (`Cache-Control` or `Expires`) to be stored. A response is **not** stored
+when it:
 
 - includes `Set-Cookie`
 - includes `Vary: *`
 - has a `5xx` status code
-- does not include `Content-Length`
-- is larger than the platform's maximum CDN object size
+- omits `Content-Length` (including unknown-length streamed responses)
+- exceeds the platform's maximum CDN object size
 
-Unknown-length streamed responses are not cached. If you want a response to be
-eligible, include a correct `Content-Length` header.
+## Cache-Control
 
-## Cache-Control semantics
-
-Use `Cache-Control` to tell Wasmer Edge whether a response can be stored and how
-long it stays fresh.
+`Cache-Control` tells Edge whether a response can be stored and how long it stays
+fresh:
 
 ```http
 Cache-Control: public, max-age=3600
 ```
 
-The response above can be cached for one hour.
+The response above can be cached for one hour. Common directives:
 
-Common directives:
+- `public` — allow storage in the shared CDN cache.
+- `private` — forbid storage in the shared CDN cache.
+- `no-store` — forbid storing the response at all.
+- `no-cache` — allow storage, but require revalidation before each reuse.
+- `max-age=<seconds>` — how long the response stays fresh.
+- `s-maxage=<seconds>` — freshness for shared caches; takes precedence over
+  `max-age`.
+- `must-revalidate` / `proxy-revalidate` — require revalidation and forbid
+  serving stale responses.
 
-- `public`: allows the response to be stored by the shared CDN cache.
-- `max-age=<seconds>`: sets how long the response is fresh.
-- `s-maxage=<seconds>`: sets the shared-cache freshness lifetime and takes
-  precedence over `max-age`.
-- `no-store`: prevents CDN Cache from storing the response.
-- `private`: prevents the shared CDN cache from storing the response.
-- `no-cache`: allows storage, but requires revalidation before reuse.
-- `must-revalidate` and `proxy-revalidate`: require revalidation and prevent
-  serving stale cached responses.
-
-If `Cache-Control` is not present, `Expires` can make a response cacheable. When
-both headers are present, `Cache-Control` takes precedence.
+When `Cache-Control` is absent, `Expires` can still make a response cacheable.
+When both are present, `Cache-Control` wins.
 
 ## Revalidation
 
-Wasmer Edge supports standard HTTP revalidation for stale cached responses.
-
-If the cached response includes `ETag`, Edge can revalidate with
-`If-None-Match`. If it includes `Last-Modified`, Edge can revalidate with
-`If-Modified-Since`. When your app returns `304 Not Modified`, Edge keeps the
-cached body and updates cache metadata from the revalidation response.
-
-For example:
+Edge supports standard HTTP revalidation for stale responses. If the cached
+response includes `ETag`, Edge revalidates with `If-None-Match`; if it includes
+`Last-Modified`, Edge revalidates with `If-Modified-Since`. When your app
+returns `304 Not Modified`, Edge keeps the cached body and refreshes its
+metadata from the response.
 
 ```http
 Cache-Control: public, max-age=60
@@ -156,40 +135,37 @@ valid instead of downloading the full body again.
 
 ## Vary
 
-`Vary` is honored when matching cached responses. For example, a response with
-`Vary: Accept-Language` is cached separately for different `Accept-Language`
-request header values.
+`Vary` is honored when matching cached responses. A response with
+`Vary: Accept-Language`, for example, is cached separately per
+`Accept-Language` value:
 
 ```http
 Cache-Control: public, max-age=3600
 Vary: Accept-Encoding
 ```
 
-`Vary: *` prevents caching. When a response has a non-identity
-`Content-Encoding`, Edge also keys the cache by `Accept-Encoding` even if the
-origin response forgot to include `Vary: Accept-Encoding`.
+`Vary: *` prevents caching. When a response uses a non-identity
+`Content-Encoding`, Edge also keys the cache by `Accept-Encoding`, even if the
+origin forgot to send `Vary: Accept-Encoding`.
 
 ## Stale responses
 
-Wasmer Edge can briefly serve stale responses during revalidation or upstream
-errors when the response is allowed to be served stale.
-
-By default, Edge uses short stale windows to smooth traffic spikes and improve
-availability during temporary upstream errors. You can control this with
-standard response directives:
+To smooth traffic spikes and stay available during brief upstream errors, Edge
+can serve stale responses for a short window during revalidation or upstream
+errors. Control this with standard directives:
 
 ```http
 Cache-Control: public, max-age=300, stale-while-revalidate=30, stale-if-error=600
 ```
 
 Edge will not serve stale responses when the request includes
-`Cache-Control: no-cache`, or when the cached response requires revalidation
-with directives such as `no-cache`, `must-revalidate`, or `proxy-revalidate`.
+`Cache-Control: no-cache`, or when the cached response requires revalidation via
+`no-cache`, `must-revalidate`, or `proxy-revalidate`.
 
-## Current limitations
+## Limitations
 
-- CDN Cache is beta.
-- `capabilities.cdn_cache.enabled` is the only app-level configuration setting.
-- Path-based caching rules are not available yet. For now, enablement applies to
-  the app, and each response controls caching through HTTP headers.
-- Dashboard and CLI purges currently purge the app's CDN cache as a whole.
+- CDN Cache is in beta.
+- `capabilities.cdn_cache.enabled` is the only app-level setting. Path-based
+  caching rules are not available yet — enablement applies to the whole app, and
+  each response controls caching through HTTP headers.
+- Dashboard and CLI purges clear the app's CDN cache as a whole.


### PR DESCRIPTION
## Summary
- Add a dedicated Edge CDN Cache configuration page
- Document `capabilities.cdn_cache.enabled`, dashboard enablement, and purge options
- Document HTTP cache header semantics and current beta limitations
- Cross-link CDN Cache from the main `app.yaml` configuration reference

## Validation
- `pnpm build`

Linear: WAX-162