### PR TITLE
Add self-hosted Umami analytics

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,6 +28,9 @@ jobs:
 
       - name: Build
         run: pnpm run build
+        env:
+          NEXT_PUBLIC_UMAMI_WEBSITE_ID: ${{ vars.NEXT_PUBLIC_UMAMI_WEBSITE_ID }}
+          NEXT_PUBLIC_UMAMI_SRC: ${{ vars.NEXT_PUBLIC_UMAMI_SRC }}
 
       - name: Setup Wasmer
         uses: wasmerio/setup-wasmer@v2

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,4 +48,8 @@ The overview of the Wasmer ecosystem can be found in `pages/index.mdx`:
 
 - Deployment: `pnpm build` + `wasmer deploy` in `publish.yaml` using `wasmer.toml`.
 - Secrets: GitHub Actions use `WASMER_CIUSER_PROD_TOKEN`—do not commit tokens or credentials.
+- Analytics: self-hosted Umami at `analytics.wasmer.io`, backend in the private
+  `wasmerio/umami-analytics` repo (running on Wasmer Edge via EdgeJS). The tracker is injected in
+  `app/layout.tsx` only when the `NEXT_PUBLIC_UMAMI_WEBSITE_ID` and `NEXT_PUBLIC_UMAMI_SRC` repo
+  variables are set at build time, so dev and preview builds send nothing.
 - External links: Prefer absolute `https://` links; validate they open in a new tab per theme defaults where appropriate.

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,13 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://docs.wasmer.io'),
 }
 
+// Self-hosted Umami analytics (analytics.wasmer.io). Both values are baked in
+// at build time, so local dev and preview builds send nothing unless they are
+// set. They ship to the browser, so they are public — repo variables, not
+// secrets.
+const umamiWebsiteId = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID
+const umamiSrc = process.env.NEXT_PUBLIC_UMAMI_SRC
+
 export default async function RootLayout({
   children,
 }: Readonly<{
@@ -30,7 +37,11 @@ export default async function RootLayout({
 
   return (
     <html lang="en" dir="ltr" suppressHydrationWarning>
-      <Head />
+      <Head>
+        {umamiWebsiteId && umamiSrc && (
+          <script defer src={umamiSrc} data-website-id={umamiWebsiteId} />
+        )}
+      </Head>
       <body>
         <DocsShell
           pageMaps={{


### PR DESCRIPTION
Adds pageview analytics to the docs site, reporting to a self-hosted [Umami](https://umami.is/) instance that runs on Wasmer Edge via EdgeJS. Backend lives in the private [`wasmerio/umami-analytics`](https://github.com/wasmerio/umami-analytics) repo.

Besides being a real gap — the docs site has no analytics of any kind today — this dogfoods EdgeJS on a substantial Next.js 16 + Prisma 7 app.

## Changes

- `app/layout.tsx` — tracker `<script>` inside Nextra's `<Head>`, rendered only when both env vars are set at build time
- `.github/workflows/publish.yaml` — passes them to the build
- `AGENTS.md` — notes where the backend lives

## Draft — blocked on the backend

`analytics.wasmer.io` is not deployed yet, and there is no website ID to configure. Two blockers, both tracked in the backend repo:

1. **Wasmer Edge's runtime needs the externref C-API** (wasmerio/wasmer#6791). Prisma 7's query compiler is a wasm-bindgen module that roots JS values in an externref table, so every DB query is WASM-inside-WASM. Released wasmer 7.2.0 cannot even instantiate the module.
2. **Memory grows ~55 kB/request with no plateau**, per the open WARP-70 Part B reference-lifetime work.

Umami itself is verified working locally on `edgejs-quickjs@0.0.0-f1d02e4` against Postgres 17 — login, full `/api/send` ingest with GeoIP, and the dashboard reporting queries.

## Config needed before merge

Two repo **variables** (not secrets — they ship to the browser):

| variable | value |
| --- | --- |
| `NEXT_PUBLIC_UMAMI_WEBSITE_ID` | from the Umami UI, once the backend is up |
| `NEXT_PUBLIC_UMAMI_SRC` | `https://analytics.wasmer.io/wa.js` |

Until they are set, the build simply omits the tag — merging early is safe but does nothing.

The tracker is served from `/wa.js` rather than Umami's default `/script.js`, which common blocklists match by filename. Note the rename is an *alias*: upstream keeps `/script.js` working too.

## Verification

Built both ways and checked the emitted static export:

- with both vars set → tag present in **89/89** HTML files
- with them unset → **0/89**

So local dev and preview builds send nothing.

Not yet verified end-to-end against a live Umami — the two sides have only been tested separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)